### PR TITLE
update README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,11 @@ Installation
   ---------------------
   * The required packages can be installed into an existing Anaconda environmnent.
   * Install major dependencies Hyperspy, OpenCV, and Astra Toolbox through conda
-  using:
+  using the following. *Note: Astra must be installed first due to an ordering
+  of the dependencies*
     ```bash
-    conda install -c conda-forge hyperspy 
-    conda install -c conda-forge opencv 
-    conda install -c conda-forge tomopy
     conda install -c astra-toolbox astra-toolbox
+    conda install -c conda-forge hyperspy opencv tomopy
     ```
 
   * Install the TomoTools package from GitLab:


### PR DESCRIPTION
After the CCEM workshop last week, I realized that installing astra after the other dependencies causes the installation to be in an inconsistent state because of the introduction of the `astra-toolbox` channel. Installing from that channel first and then using `conda-forge` for the other dependencies seems to get everything in working order, so I've updated the instructions in the README to match.