### PR TITLE
Enable use as hyperspy extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ libraries, [conda](https://anaconda.org/anaconda/conda) is the simplest way to
 get started. It will auto-detect CUDA-capable GPUs and install the correct version
 of whatever packages are required.
 
+> ⚠️ ETSpy requires a Python version `>= 3.10` and `< 3.13` (3.13 and above are not supported due to dependencies).
+> If installing manually using `pip`, please ensure you are using a supported version.
+
 ### Anaconda (Preferred)
 
   *Works on Windows, MacOS, and Linux*
@@ -47,13 +50,12 @@ of whatever packages are required.
 
 ####  Optional Jupyter components (higly recommended)
 
-  * To use ETSpy from within a Jupyter Lab/Notebook environment, a few other optional 
-    dependencies are required.
-    * `ipympl` enables interactive plotting in Jupyter Lab or Notebook.  
+  * To use ETSpy from within a Jupyter Lab/Notebook environment, a other optional 
+    dependencies are required:
     * `ipykernel` allows use of the the etspy kernel with Jupyter installed in a different environment. 
 
     ```shell
-    (etspy) $ conda install ipympl ipykernel
+    (etspy) $ conda install ipykernel
     ```
 
   * To "register" the python kernel associated with the `etspy` conda environment, run
@@ -68,12 +70,12 @@ of whatever packages are required.
 
 ###  Using pip
 
-  *Works on Linux, with additional prerequisites*
+  *Works on Linux only, with additional prerequisites*
 
   Assuming you have the prequisite packages on your system (including
   the [CUDA libraries](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html)),
   ETSpy should be able to be installed with a simple `pip` command (it is recommended to install
-  ETSpy in a dedicated virtual environment):
+  ETSpy in a dedicated virtual environment). Pick one of the following options depending on your needs:
 
   ```{tip}
   On Ubuntu-based systems, the NVIDIA/CUDA dependencies installed via the system-provided `nvidia-cuda-toolkit` apt package may be out of date and incompatible with the ASTRA toolkit. We recommend installing the version directly from NVIDIA.
@@ -84,12 +86,25 @@ of whatever packages are required.
     ```
 
   * To use ETSpy in Jupyter interface from within a dedicated virtual environment, installing
-    `ipykernel` and `ipympl` are necessary (as with Anaconda). This can be done by specifying
+    `ipykernel` is necessary (as with Anaconda). This can be done by specifying
     the `[jupyter]` group when installing ETSpy:
 
     ```shell
     $ pip install etspy[jupyter]
     ```
+
+  * To use the `cupy` accelerated code in ETSpy, you will need to install `cupy`. 
+    This can be done by specifying the `[gpu]` group when installing ETSpy:
+
+    ```shell
+    $ pip install etspy[gpu]
+    ```
+
+  * A shortcut for doing both of the above is to install the `[all]` target:
+
+    ```shell
+    $ pip install etspy[all]
+    ```  
 
   * To register the ETSpy virtual environment as a Jupyter kernel, run the following with
     the virtual environment enabled:
@@ -132,7 +147,7 @@ CUDA libraries installed, clone the `etspy` repository, and run the install comm
 ```shell
 $ git clone https://github.com/usnistgov/etspy
 $ cd etspy
-$ poetry install
+$ poetry install   # (to get the cupy dependency add "--with=gpu" to the install command)
 ```
 
 ```{note}
@@ -248,6 +263,27 @@ when running "Debug test" via the `PYTEST_ADDOPTS` environment variable:
       "env": {"PYTEST_ADDOPTS": "--no-cov"}
   }
 ```
+
+### Releasing a version
+
+*Note: this is primarily documentation for the developers. Feel free to ignore if you just wish to use ETSpy.*
+
+#### Testing a pre-release
+
+```bash
+# bump version using poetry
+$ poetry version prerelease  # this will append the version number and a pre-release indicator e.g ".a0"
+$ poetry lock  # ensure you've updated the lockfile and any dependencies
+$ poetry build  # buildssource and binary "wheel" distributions
+$ poetry publish  # requires registering poetry with tokens for your PyPI account (see https://python-poetry.org/docs/repositories/#configuring-credentials )
+```
+
+You should then be able to install from PyPI with the new version (e.g. `pip install etspy==0.9.3a2`)
+
+#### Releasing a new version
+
+- Basically the same as above, but run `poetry version patch` rather than `prerelease`.
+- Should also create a git tag for the version, and create a release on GitHub. This may be done automatically in the future.
 
 ## Related projects
 

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -94,6 +94,9 @@ class TomoShifts(Signal1D):
     4
     """
 
+    _signal_type = "TomoShifts"
+    _signal_dimension = 1
+
     def __init__(self, data, *args, **kwargs):
         """
         Create a TomoShifts signal instance.
@@ -163,6 +166,9 @@ class TomoTilts(Signal1D):
     -----
     5
     """
+
+    _signal_type = "TomoTilts"
+    _signal_dimension = 1
 
     def __init__(self, data, *args, **kwargs):
         """
@@ -240,6 +246,9 @@ class CommonStack(Signal2D, ABC):
     -----
     3
     """
+
+    _signal_type = "CommonStack"
+    _signal_dimension = 2
 
     def _create_from_signal(self, data, tilts, *args, **kwargs):
         """Create stack from HyperSpy signal (helper method for __init__)."""
@@ -1014,6 +1023,9 @@ class TomoStack(CommonStack):
     -----
     1
     """
+
+    _signal_type = "TomoStack"
+    _signal_dimension = 2
 
     def __init__(self, *args, **kwargs):
         """
@@ -2002,6 +2014,9 @@ class RecStack(CommonStack):
     -----
     2
     """
+
+    _signal_type = "RecStack"
+    _signal_dimension = 2
 
     def __init__(self, *args, **kwargs):
         """

--- a/etspy/hyperspy_extension.yaml
+++ b/etspy/hyperspy_extension.yaml
@@ -1,0 +1,31 @@
+signals:
+    TomoStack:
+        signal_type: "TomoStack"
+        signal_type_aliases:
+            - Tomography
+            - Tomography stack
+            - TiltStack
+        signal_dimension: 2
+        dtype: real
+        lazy: False
+        module: etspy.base
+    RecStack:
+        signal_type: "RecStack"
+        signal_type_aliases:
+            - Reconstructed stack
+        signal_dimension: 2
+        dtype: real
+        lazy: False
+        module: etspy.base
+    TomoShifts:
+        signal_type: "TomoShifts"
+        signal_dimension: 1
+        dtype: real
+        lazy: False
+        module: etspy.base
+    TomoTilts:
+        signal_type: "TomoTilts"
+        signal_dimension: 1
+        dtype: real
+        lazy: False
+        module: etspy.base

--- a/etspy/hyperspy_extension.yaml
+++ b/etspy/hyperspy_extension.yaml
@@ -17,15 +17,3 @@ signals:
         dtype: real
         lazy: False
         module: etspy.base
-    TomoShifts:
-        signal_type: "TomoShifts"
-        signal_dimension: 1
-        dtype: real
-        lazy: False
-        module: etspy.base
-    TomoTilts:
-        signal_type: "TomoTilts"
-        signal_dimension: 1
-        dtype: real
-        lazy: False
-        module: etspy.base

--- a/poetry.lock
+++ b/poetry.lock
@@ -537,7 +537,7 @@ toml = ["tomli"]
 name = "cupy"
 version = "13.3.0"
 description = "CuPy: NumPy & SciPy for GPU"
-optional = false
+optional = true
 python-versions = ">=3.9"
 files = [
     {file = "cupy-13.3.0.tar.gz", hash = "sha256:9a2a17af2b99cce91dd1366939c3805e3f51f9de5046df64f29ccbad3bdf78ed"},
@@ -700,7 +700,7 @@ devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benc
 name = "fastrlock"
 version = "0.8.2"
 description = "Fast, re-entrant optimistic lock implemented in Cython"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "fastrlock-0.8.2-cp27-cp27m-macosx_10_15_x86_64.whl", hash = "sha256:94e348c72a1fd1f8191f25ea056448e4f5a87b8fbf005b39d290dcb0581a48cd"},
@@ -2437,13 +2437,13 @@ xxhash = ["xxhash (>=1.4.3)"]
 
 [[package]]
 name = "prettytable"
-version = "3.11.0"
+version = "3.12.0"
 description = "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "prettytable-3.11.0-py3-none-any.whl", hash = "sha256:aa17083feb6c71da11a68b2c213b04675c4af4ce9c541762632ca3f2cb3546dd"},
-    {file = "prettytable-3.11.0.tar.gz", hash = "sha256:7e23ca1e68bbfd06ba8de98bf553bf3493264c96d5e8a615c0471025deeba722"},
+    {file = "prettytable-3.12.0-py3-none-any.whl", hash = "sha256:77ca0ad1c435b6e363d7e8623d7cc4fcf2cf15513bf77a1c1b2e814930ac57cc"},
+    {file = "prettytable-3.12.0.tar.gz", hash = "sha256:f04b3e1ba35747ac86e96ec33e3bb9748ce08e254dc2a1c6253945901beec804"},
 ]
 
 [package.dependencies]
@@ -2546,10 +2546,7 @@ files = [
 [package.dependencies]
 annotated-types = ">=0.6.0"
 pydantic-core = "2.23.4"
-typing-extensions = [
-    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
-    {version = ">=4.6.1", markers = "python_version < \"3.13\""},
-]
+typing-extensions = {version = ">=4.6.1", markers = "python_version < \"3.13\""}
 
 [package.extras]
 email = ["email-validator (>=2.0.0)"]
@@ -3990,7 +3987,12 @@ enabler = ["pytest-enabler (>=2.2)"]
 test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
 type = ["pytest-mypy"]
 
+[extras]
+all = ["cupy", "ipykernel"]
+gpu = ["cupy"]
+jupyter = ["ipykernel"]
+
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10"
-content-hash = "de068bf636f67a4b5cf3902f2e5eeea3f1ae24ee7acbd126c303322ce48fec79"
+python-versions = ">=3.10, <3.13"
+content-hash = "4252c15bb255c7bc63f1f58896f4731e875d94399151e99f150d5c8e8336ee6d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "etspy"
-version = "0.9.1"
+version = "0.9.3a3"
 description = "Suite of tools for processing and reconstruction of electron tomography data"
 authors = [
     "Andrew A. Herzing <andrew.herzing@nist.gov>",
@@ -16,14 +16,19 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = ">=3.10, <3.13"
 pystackreg = "^0.2.8"
 astra-toolbox = "^2.2.0"
 hyperspy = "^2.1.1"
 hyperspy-gui-ipywidgets = "^2.0.2"
-ipykernel = "^6.29.5"
 numba = "^0.60.0"
 typing-extensions = "^4.12.2"
+h5py = "^3.12.1"
+
+# extra optional dependencies for the "extras" groups (for "pip install etspy[...]")
+ipykernel = {version = "^6.29.5", optional = true}
+cupy = {version = "^13.3.0", optional = true}
+numpy = "^2.0"
 
 [tool.poetry.group.dev.dependencies]
 pydocstyle = "^6.3.0"
@@ -38,19 +43,25 @@ myst-nb = "^1.1.2"
 pytest-cov = "^5.0.0"
 tomli = "^2.0.2"
 
-[tool.poetry.group.jupyter.dependencies]
-ipympl = "^0.9.4"
-ipykernel = "^6.29.5"
-
-[tool.poetry.group.gpu]
-optional = true
 
 [tool.poetry.group.gpu.dependencies]
-cupy = "^13.3.0"
+cupy = {version = "^13.3.0", optional = true}
+
+
+[tool.poetry.group.jupyter.dependencies]
+ipykernel = "^6.29.5"
+
+[tool.poetry.extras]
+gpu = ["cupy"]
+jupyter = ["ipykernel"]
+all = ["cupy", "ipykernel"]  # shortcut for all extras
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.plugins."hyperspy.extensions"]
+etspy = "etspy"
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "etspy"
-version = "0.9.3a3"
+version = "0.9.3"
 description = "Suite of tools for processing and reconstruction of electron tomography data"
 authors = [
     "Andrew A. Herzing <andrew.herzing@nist.gov>",


### PR DESCRIPTION
- Adds hyperspy extension metadata, allowing use such as follows:

```
 $ poetry run python -c "import hyperspy.api as hs; hs.print_known_signal_types()"
+-------------+-----------------------------------------+------------+---------+
| signal_type |                 aliases                 | class name | package |
+-------------+-----------------------------------------+------------+---------+
|   RecStack  |           Reconstructed stack           |  RecStack  |  etspy  |
|  TomoStack  | Tomography, Tomography stack, TiltStack | TomoStack  |  etspy  |
+-------------+-----------------------------------------+------------+---------+
```
- Updates version to 0.9.3 (skipped 0.9.2 because of problems when I was testing packaging)
- Fixes `pyproject.toml` to allow installation via pip including the use of "extras" groups `gpu`, `jupyter`, and `all`