### PR TITLE
Draft: some improvements on separate init branch

### DIFF
--- a/etspy/align.py
+++ b/etspy/align.py
@@ -1011,7 +1011,10 @@ def tilt_maximage(
         nshifts = shifts.shape[0]
         shifted = ali.isig[0:nshifts, :].deepcopy()
         for i in range(nshifts):
-            shifted.data[:, :, i] = np.roll(ali.isig[idx, :].data, int(shifts[i]))
+            shifted.data[:, :, i] = np.roll(
+                ali.isig[idx, :].data.squeeze(),
+                int(shifts[i]),
+            )
         shifted_rec = shifted.reconstruct("SIRT", 100, constrain=True)
         image_sum = cast(BaseSignal, shifted_rec.sum(axis=(1, 2)))
         tilt_shift = shifts[image_sum.data.argmin()]

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -334,47 +334,6 @@ class CommonStack(Signal2D, ABC):
         """
         super().plot(navigator=navigator, *args, **kwargs)  # noqa: B026
 
-    def deepcopy(self):
-        """
-        Return a "deep copy" of this Stack.
-
-        Uses the standard library's :func:`~copy.deepcopy` function. Note: this means
-        the underlying data structure will be duplicated in memory.
-
-        Overrides the :py:meth:`~hyperspy.api.signals.BaseSignal.deepcopy`
-        method to ensure the ``tilts`` and ``shifts`` properties are also copied
-
-        See Also
-        --------
-        :py:meth:`~etspy.base.CommonStack.copy`
-        """
-        s = copy.deepcopy(self)
-        if hasattr(self, "tilts"):
-            s.tilts = copy.deepcopy(self.tilts)
-        if hasattr(self, "shifts"):
-            s.shifts = copy.deepcopy(self.shifts)
-        return s
-
-    def copy(self):
-        """
-        Return a "shallow copy" of this Stack.
-
-        Uses the standard library's :func:`~copy.copy` function. Note: this will
-        return a copy of the, Stack, but it will not duplicate the underlying
-        data in memory, and both Stacks will reference the same data.
-
-        Overrides the :py:meth:`~hyperspy.api.signals.BaseSignal.copy`
-        method to ensure the ``tilts`` and ``shifts`` properties are also copied
-
-        See Also
-        --------
-        :py:meth:`~etspy.base.CommonStack.deepcopy`
-        """
-        s = copy.copy(self)
-        s.tilts = copy.copy(self.tilts)
-        s.shifts = copy.copy(self.shifts)
-        return s
-
     def change_data_type(self, dtype: Union[str, np.dtype]):
         """
         Change the data type of a stack.
@@ -1103,6 +1062,46 @@ class TomoStack(CommonStack):
             TomoTilts,
             self.shift_and_tilt_setter("tilts", np.zeros_like(self.tilts.data)),
         )
+
+
+    def deepcopy(self):
+        """
+        Return a "deep copy" of this Stack.
+
+        Uses the standard library's :func:`~copy.deepcopy` function. Note: this means
+        the underlying data structure will be duplicated in memory.
+
+        Overrides the :py:meth:`~hyperspy.api.signals.BaseSignal.deepcopy`
+        method to ensure the ``tilts`` and ``shifts`` properties are also copied
+
+        See Also
+        --------
+        :py:meth:`~etspy.base.TomoStack.copy`
+        """
+        s = copy.deepcopy(self)
+        s.tilts = copy.deepcopy(self.tilts)
+        s.shifts = copy.deepcopy(self.shifts)
+        return s
+
+    def copy(self):
+        """
+        Return a "shallow copy" of this Stack.
+
+        Uses the standard library's :func:`~copy.copy` function. Note: this will
+        return a copy of the, Stack, but it will not duplicate the underlying
+        data in memory, and both Stacks will reference the same data.
+
+        Overrides the :py:meth:`~hyperspy.api.signals.BaseSignal.copy`
+        method to ensure the ``tilts`` and ``shifts`` properties are also copied
+
+        See Also
+        --------
+        :py:meth:`~etspy.base.TomoStack.deepcopy`
+        """
+        s = copy.copy(self)
+        s.tilts = copy.copy(self.tilts)
+        s.shifts = copy.copy(self.shifts)
+        return s
 
     def plot_sinos(self, *args: Tuple, **kwargs: Dict):
         """

--- a/etspy/datasets.py
+++ b/etspy/datasets.py
@@ -9,6 +9,8 @@ def get_needle_data(aligned: bool = False):
     """
     Load an experimental tilt series of needle-shaped specimen.
 
+    Data size is 77 tilt projections and 256 x 256 pixel images.
+
     Returns
     -------
     needle : TomoStack
@@ -39,6 +41,8 @@ def get_catalyst_data(
 ) -> etspy.TomoStack:
     """
     Load a model-simulated catalyst tilt series.
+
+    Data size is 90 tilt projections and 600 x 600 pixel images.
 
     Parameters
     ----------

--- a/etspy/recon.py
+++ b/etspy/recon.py
@@ -503,8 +503,8 @@ def astra_error(
     Parameters
     ----------
     sinogram
-       Tilt series data either of the form [angles, x] or [angles, y, x] where
-       y is the tilt axis and x is the projection axis.
+       Tilt series data of the shape ``(n_angles, n_y)``, where
+       y is the axis perpendicular to the tilt axis.
     angles
         Projection angles in degrees.
     method
@@ -533,6 +533,13 @@ def astra_error(
     recon
     """
     thetas = angles * np.pi / 180
+
+    if len(sinogram.shape) != 2:  # noqa: PLR2004
+        msg = (
+            "Sinogram must be two-dimensional (ntilts, y). Provided shape "
+            f"was {sinogram.shape}."
+        )
+        raise ValueError(msg)
 
     nangles, ny = sinogram.shape
 

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -862,29 +862,9 @@ class TestSlicers:
 class TestExtractSinogram:
     """Test extract_sinogram method."""
 
-    def test_extract_sinogram_row(self):
+    def test_extract_sinogram(self):
         stack = ds.get_catalyst_data()
-        sino = stack.extract_sinogram(row=300)
-        ax_0, ax_1 = cast(list[Uda], [sino.axes_manager[i] for i in range(2)])
-        assert sino.axes_manager.shape == (600, 90)
-        assert sino.metadata.get_item("Signal.signal_type") == ""
-        assert ax_0.name == "x"
-        assert ax_1.name == "Projections"
-        assert sino.metadata.get_item("General.title") == "Sinogram at row 300"
-
-    def test_extract_sinogram_row_float(self):
-        stack = ds.get_catalyst_data()
-        sino = stack.extract_sinogram(row=102.3)
-        ax_0, ax_1 = cast(list[Uda], [sino.axes_manager[i] for i in range(2)])
-        assert sino.axes_manager.shape == (600, 90)
-        assert sino.metadata.get_item("Signal.signal_type") == ""
-        assert ax_0.name == "x"
-        assert ax_1.name == "Projections"
-        assert sino.metadata.get_item("General.title") == "Sinogram at y = 102.3 nm"
-
-    def test_extract_sinogram_column(self):
-        stack = ds.get_catalyst_data()
-        sino = stack.extract_sinogram(column=300)
+        sino = stack.extract_sinogram(300)
         ax_0, ax_1 = cast(list[Uda], [sino.axes_manager[i] for i in range(2)])
         assert sino.axes_manager.shape == (600, 90)
         assert sino.metadata.get_item("Signal.signal_type") == ""
@@ -892,9 +872,9 @@ class TestExtractSinogram:
         assert ax_1.name == "Projections"
         assert sino.metadata.get_item("General.title") == "Sinogram at column 300"
 
-    def test_extract_sinogram_column_float(self):
+    def test_extract_sinogram_float(self):
         stack = ds.get_catalyst_data()
-        sino = stack.extract_sinogram(column=106.32)
+        sino = stack.extract_sinogram(106.32)
         ax_0, ax_1 = cast(list[Uda], [sino.axes_manager[i] for i in range(2)])
         assert sino.axes_manager.shape == (600, 90)
         assert sino.metadata.get_item("Signal.signal_type") == ""
@@ -902,28 +882,25 @@ class TestExtractSinogram:
         assert ax_1.name == "Projections"
         assert sino.metadata.get_item("General.title") == "Sinogram at x = 106.32 nm"
 
-    def test_extract_sinogram_neither_row_nor_column(self):
+    def test_extract_sinogram_bad_argument_type(self):
         stack = ds.get_catalyst_data()
         with pytest.raises(
-            ValueError,
-            match=re.escape('One of "column" or "row" must be provided.'),
+            TypeError,
+            match=re.escape(
+                '"column" argument must be either a float or an integer '
+                "(was <class 'str'>)",
+            ),
         ):
-            stack.extract_sinogram()
+            stack.extract_sinogram("bad_val") # type: ignore
 
-    def test_extract_sinogram_both_row_and_column(self):
-        stack = ds.get_catalyst_data()
-        with pytest.raises(
-            ValueError,
-            match=re.escape('Only one of "column" or "row" may be provided.'),
-        ):
-            stack.extract_sinogram(row=300, column=200)
 
     def test_extract_sinogram_exception_handling(self):
         # test that on exception, logger is still enabled
         stack = ds.get_catalyst_data()
         assert logging.getLogger("etspy.base").disabled is False
         with pytest.raises(IndexError):
-            stack.extract_sinogram(column="weird") # type: ignore
+            # using too large of a value should trigger an error
+            stack.extract_sinogram(column=10000)
         assert logging.getLogger("etspy.base").disabled is False
 
 class TestFiltering:

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -154,8 +154,8 @@ class TestTomoStack:
         assert hasattr(stack, "tilts")
         assert hasattr(stack, "shifts")
         assert not stack.metadata.get_item("Tomography.cropped")
-        assert stack.metadata.get_item("Tomography.xshift") == 2  # noqa: PLR2004
-        assert stack.metadata.get_item("Tomography.yshift") == 3  # noqa: PLR2004
+        assert stack.metadata.get_item("Tomography.xshift") == 2
+        assert stack.metadata.get_item("Tomography.yshift") == 3
         assert stack.metadata.get_item("Tomography.tiltaxis") == 1
         assert stack.metadata.get_item("General.title") == "Test title"
 
@@ -175,9 +175,9 @@ class TestTomoStack:
         assert hasattr(stack, "tilts")
         assert hasattr(stack, "shifts")
         assert not stack.metadata.get_item("Tomography.cropped")
-        assert stack.metadata.get_item("Tomography.xshift") == 10  # noqa: PLR2004
-        assert stack.metadata.get_item("Tomography.yshift") == 20  # noqa: PLR2004
-        assert stack.metadata.get_item("Tomography.tiltaxis") == -5  # noqa: PLR2004
+        assert stack.metadata.get_item("Tomography.xshift") == 10
+        assert stack.metadata.get_item("Tomography.yshift") == 20
+        assert stack.metadata.get_item("Tomography.tiltaxis") == -5
         assert stack.metadata.get_item("General.title") == "test signal"
 
     def test_tomostack_create_by_signal_without_tomometa_dict(self):
@@ -259,7 +259,7 @@ class TestTomoStack:
         assert stack.axes_manager[0].units == "test units"  # type: ignore
         # signal dimensions are always renamed to just "x" and "y":
         assert stack.axes_manager[-1].name == "y"  # type: ignore
-        assert stack.axes_manager[-1].scale == 0.123  # type: ignore  # noqa: PLR2004
+        assert stack.axes_manager[-1].scale == 0.123  # type: ignore
 
     def test_tomostack_create_by_signal_undefined_axes(self):
         s = cast(Signal2D, hs.signals.Signal2D(np.random.random([10, 100, 100])))
@@ -1426,9 +1426,27 @@ class TestManualAlign:
         shifted = stack.manual_align(64, display=True)
         assert isinstance(shifted, TomoStack)
 
+class TestRecStack:
+    """Test creating RecStacks."""
 
-class TestPlotSlices:
-    """Test plotting slices of a TomoStack."""
+    def test_rec_stack_init(self):
+        rec = RecStack(np.random.rand(10, 11, 12))
+        assert isinstance(rec, RecStack)
+        assert rec.metadata.get_item("Signal.signal_type") == "RecStack"
+        assert rec.axes_manager.shape == (10, 12, 11)
+
+    def test_rec_stack_init_bad_dims(self):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "A RecStack must have a singular navigation axis. "
+                "Navigation shape was: (8, 10)",
+            ),
+        ):
+            RecStack(np.random.rand(10, 8, 11, 12))
+
+class TestRecStackPlotSlices:
+    """Test plotting slices of a RecStack."""
 
     def test_plot_slices(self):
         rec = RecStack(np.zeros([10, 10, 10]))

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -120,7 +120,7 @@ class TestCommonStack:
         with pytest.raises(
             ValueError,
             match=re.escape(
-                "Invalid axis 'not valid'. Must be one of ['XY', 'YZ', or 'XZ'].",
+                'Invalid axis "not valid". Must be one of ["XY", "YZ", or "XZ"].',
             ),
         ):
             s.save_movie(start=0, stop=100, outfile="", axis="not valid")  # type: ignore

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -63,36 +63,6 @@ class TestCommonStack:
         assert s2.shifts.data.shape == (5, 2)
         assert s2.tilts.data.shape == (5, 1)
 
-    def test_deepcopy(self):
-        s = ds.get_needle_data()
-        s2 = s.deepcopy()
-        assert np.all(s.data == s2.data)
-        assert np.all(s.tilts.data == s2.tilts.data)
-        assert np.all(s.shifts.data == s2.shifts.data)
-        assert s is not s2
-        assert s.data is not s2.data
-        assert s.tilts.data is not s2.tilts.data
-        assert s.shifts.data is not s2.shifts.data
-        np.testing.assert_equal(
-            s.metadata.as_dictionary(),
-            s2.metadata.as_dictionary(),
-        )
-
-    def test_copy(self):
-        s = ds.get_needle_data()
-        s2 = s.copy()
-        assert np.all(s.data == s2.data)
-        assert np.all(s.tilts.data == s2.tilts.data)
-        assert np.all(s.shifts.data == s2.shifts.data)
-        assert s is not s2
-        assert s.data is s2.data
-        assert s.tilts.data is s2.tilts.data
-        assert s.shifts.data is s2.shifts.data
-        np.testing.assert_equal(
-            s.metadata.as_dictionary(),
-            s2.metadata.as_dictionary(),
-        )
-
     def test_plot(self):
         s = ds.get_needle_data()
         s.plot()
@@ -328,6 +298,36 @@ class TestTomoStack:
                 "Must be either 0, 1, or 2."),
         ):
             TomoStack(n)
+
+    def test_deepcopy(self):
+        s = ds.get_needle_data()
+        s2 = s.deepcopy()
+        assert np.all(s.data == s2.data)
+        assert np.all(s.tilts.data == s2.tilts.data)
+        assert np.all(s.shifts.data == s2.shifts.data)
+        assert s is not s2
+        assert s.data is not s2.data
+        assert s.tilts.data is not s2.tilts.data
+        assert s.shifts.data is not s2.shifts.data
+        np.testing.assert_equal(
+            s.metadata.as_dictionary(),
+            s2.metadata.as_dictionary(),
+        )
+
+    def test_copy(self):
+        s = ds.get_needle_data()
+        s2 = s.copy()
+        assert np.all(s.data == s2.data)
+        assert np.all(s.tilts.data == s2.tilts.data)
+        assert np.all(s.shifts.data == s2.shifts.data)
+        assert s is not s2
+        assert s.data is s2.data
+        assert s.tilts.data is s2.tilts.data
+        assert s.shifts.data is s2.shifts.data
+        np.testing.assert_equal(
+            s.metadata.as_dictionary(),
+            s2.metadata.as_dictionary(),
+        )
 
     def test_remove_projections(self):
         s = ds.get_needle_data(aligned=True)

--- a/etspy/tests/test_recon.py
+++ b/etspy/tests/test_recon.py
@@ -140,6 +140,16 @@ class TestReconRun:
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)
 
+    def test_run_fbp_no_cuda_2d_array(self):
+        stack = ds.get_needle_data(aligned=True)
+        slices = stack.isig[120:121, :].deepcopy()
+        tilts = slices.tilts.data.squeeze()
+        rec = recon.run(slices.data.squeeze(), tilts, "FBP", cuda=False)
+        data_shape = cast(Tuple[int, int, int], rec.data.shape)
+        assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
+        assert data_shape[0] == slices.data.shape[2]
+        assert isinstance(rec, np.ndarray)
+
     def test_run_sirt_no_cuda(self):
         stack = ds.get_needle_data(aligned=True)
         slices = stack.isig[120:121, :].deepcopy()
@@ -236,7 +246,7 @@ class TestAstraError:
         stack = ds.get_needle_data(aligned=True)
         _, ny, _ = stack.data.shape
         angles = stack.tilts.data.squeeze()
-        sino = stack.isig[120, :].data
+        sino = stack.isig[120, :].data.squeeze()
         rec_stack, error = recon.astra_error(
             sino,
             angles,
@@ -252,7 +262,7 @@ class TestAstraError:
         stack = ds.get_needle_data(aligned=True)
         _, ny, _ = stack.data.shape
         angles = stack.tilts.data.squeeze()
-        sino = stack.isig[120, :].data
+        sino = stack.isig[120, :].data.squeeze()
         rec_stack, error = recon.astra_error(
             sino,
             angles,


### PR DESCRIPTION
Per our conversation on Friday...

- Slicing with a single location with `isig` now emits a warning, and coerces the shape to `(ntilts | 1, y)` :

```
>>> s = ds.get_catalyst_data(misalign=False)
>>> s.isig[20, :]
Slicing a TomoStack signal axis with a single pixel is not supported. Returning a single pixel on the "x" axis instead
<TomoStack, title: , dimensions: (90|1, 600)>

>>> s.isig[:, 200]
Slicing a TomoStack signal axis with a single pixel is not supported. Returning a single pixel on the "y" axis instead
<TomoStack, title: , dimensions: (90|600, 1)>
```

- Added an `extract_sinogram()` method that supports both integer and float-based indexing:

![image](https://github.com/user-attachments/assets/a56f0da6-e423-4f97-bbb9-d0926e97b1bb)

- Fixed some axes-handling issues that were causing tests to fail.

## Todos:

- [x] Test/check test output of CUDA code
- [x] Add coverage for RecStack constructor
- [x] A few other little things I found

But wanted you to see this so we don't duplicate efforts
