### PR TITLE
ENH Add Fourier shift option

### DIFF
--- a/etspy/align.py
+++ b/etspy/align.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 has_cupy = True
 try:
     import cupy as cp  # type: ignore
-    import cupyx.scipy as scipyx
+    from cupyx import scipy as scipyx
 except ImportError:
     has_cupy = False
 
@@ -1175,6 +1175,7 @@ def align_to_other(
     stack: "TomoStack",
     other: "TomoStack",
     shift_type: Literal["fourier", "interp"] = "interp",
+    cuda: bool = False,
 ) -> "TomoStack":
     """
     Spatially register a TomoStack using previously calculated shifts.
@@ -1214,7 +1215,10 @@ def align_to_other(
     yshift = cast(float, stack_tomo_meta.yshift)
     out_tomo_meta.yshift = stack_tomo_meta.yshift
 
-    out = apply_shifts(out, stack.shifts, shift_type)
+    if cuda:
+        out = apply_shifts_cuda(out, stack.shifts, shift_type)
+    else:
+        out = apply_shifts(out, stack.shifts, shift_type)
 
     if stack_tomo_meta.cropped:
         out = shift_crop(out)

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -100,7 +100,7 @@ def get_coms(stack: "TomoStack", slices: np.ndarray) -> np.ndarray:
 def apply_shifts(
     stack: "TomoStack",
     shifts: Union["TomoShifts", np.ndarray],
-    method: Literal["interp", "fourier"] = "interp",
+    method: Literal["interp", "fourier"] = "fourier",
 ) -> "TomoStack":
     """
     Apply a series of shifts to a TomoStack.
@@ -192,7 +192,7 @@ def apply_shifts(
 def apply_shifts_cuda(
     stack: "TomoStack",
     shifts: Union["TomoShifts", np.ndarray],
-    method: Literal["interp", "fourier"] = "interp",
+    method: Literal["interp", "fourier"] = "fourier",
 ) -> "TomoStack":
     """
     Apply a series of shifts to a TomoStack using CUDA acceleration.
@@ -806,7 +806,7 @@ def align_stack(  # noqa: PLR0913
     start: Optional[int],
     show_progressbar: bool,
     xrange: Optional[Tuple[int, int]] = None,
-    shift_type: Literal["fourier", "interp"] = "interp",
+    shift_type: Literal["fourier", "interp"] = "fourier",
     p: int = 20,
     nslices: int = 20,
     cuda: bool = False,
@@ -1175,7 +1175,7 @@ def tilt_maximage(
 def align_to_other(
     stack: "TomoStack",
     other: "TomoStack",
-    shift_type: Literal["fourier", "interp"] = "interp",
+    shift_type: Literal["fourier", "interp"] = "fourier",
     cuda: bool = False,
 ) -> "TomoStack":
     """

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -27,7 +27,8 @@ if TYPE_CHECKING:
 has_cupy = True
 try:
     import cupy as cp  # type: ignore
-    from cupyx import scipy as scipyx
+    from cupyx.scipy.ndimage import fourier_shift as fourier_shift_gpu
+    from cupyx.scipy.ndimage import shift as shift_gpu
 except ImportError:
     has_cupy = False
 
@@ -236,7 +237,7 @@ def apply_shifts_cuda(
 
     if method.lower() == "interp":
         for i in range(data.shape[0]):
-            data[i, :, :] = scipyx.ndimage.shift(
+            data[i, :, :] = shift_gpu(
                 data[i, :, :],
                 shift=[shifts[i, 0], shifts[i, 1]],
             )
@@ -260,7 +261,7 @@ def apply_shifts_cuda(
         data_fft = cp.fft.fft2(data, axes=(1, 2))
         for i in range(data.shape[0]):
             data_fft[i, :, :] = cp.fft.ifft2(
-                scipyx.ndimage.fourier_shift(
+                fourier_shift_gpu(
                     data_fft[i],
                     shift=[shifts[i, 0], shifts[i, 1]],
                 ),

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -1235,7 +1235,11 @@ class TomoStack(CommonStack):
         return fig
 
     # TODO: allow a list of signals for 'other'
-    def align_other(self, other: "TomoStack") -> "TomoStack":
+    def align_other(
+        self,
+        other: "TomoStack",
+        shift_type: Literal["interp", "fourier"] = "interp",
+    ) -> "TomoStack":
         """
         Apply the alignment calculated for one dataset to another.
 
@@ -1248,6 +1252,10 @@ class TomoStack(CommonStack):
             The tilt series which is to be aligned using the previously
             calculated parameters. The data array in the TomoStack must be of
             the same size as that in ``self.data``
+        shift_type
+            Image shifts can be applied using either interpolation via
+            scipy.ndimage.shift or via Fourier shift as implemented in
+            scipy.ndimage.fourier_shift.  Must be either 'interp' or 'fourier'.
 
         Returns
         -------
@@ -1280,7 +1288,7 @@ class TomoStack(CommonStack):
             msg = "No transformations have been applied to this stack"
             raise ValueError(msg)
 
-        out = align.align_to_other(self, other)
+        out = align.align_to_other(self, other, shift_type)
 
         return out
 

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -1239,6 +1239,7 @@ class TomoStack(CommonStack):
         self,
         other: "TomoStack",
         shift_type: Literal["interp", "fourier"] = "interp",
+        cuda: bool = False,
     ) -> "TomoStack":
         """
         Apply the alignment calculated for one dataset to another.
@@ -1256,6 +1257,8 @@ class TomoStack(CommonStack):
             Image shifts can be applied using either interpolation via
             scipy.ndimage.shift or via Fourier shift as implemented in
             scipy.ndimage.fourier_shift.  Must be either 'interp' or 'fourier'.
+        cuda
+            Whether or not to use CUDA-accelerated reconstruction algorithms.
 
         Returns
         -------
@@ -1288,7 +1291,7 @@ class TomoStack(CommonStack):
             msg = "No transformations have been applied to this stack"
             raise ValueError(msg)
 
-        out = align.align_to_other(self, other, shift_type)
+        out = align.align_to_other(self, other, shift_type, cuda)
 
         return out
 

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -1238,7 +1238,7 @@ class TomoStack(CommonStack):
     def align_other(
         self,
         other: "TomoStack",
-        shift_type: Literal["interp", "fourier"] = "interp",
+        shift_type: Literal["interp", "fourier"] = "fourier",
         cuda: bool = False,
     ) -> "TomoStack":
         """
@@ -1396,7 +1396,7 @@ class TomoStack(CommonStack):
         cl_resolution: float = 0.05,
         cl_div_factor: int = 8,
         cuda: bool = False,
-        shift_type: Literal["interp", "fourier"] = "interp",
+        shift_type: Literal["interp", "fourier"] = "fourier",
     ) -> "TomoStack":
         """
         Register stack spatially.

--- a/etspy/tests/test_align.py
+++ b/etspy/tests/test_align.py
@@ -16,6 +16,7 @@ from etspy import datasets as ds
 
 cupy_in_test_env = find_spec("cupy") is not None
 
+
 class TestAlignFunctions:
     """Test alignment functions."""
 
@@ -83,8 +84,10 @@ class TestAlignFunctions:
     def test_tilt_com_no_slices_yes_nslices_30_perc(self, caplog):
         stack = ds.get_needle_data()
         etspy.align.tilt_com(stack, slices=None, nslices=100)
-        assert ("nslices is greater than 30% of number of x pixels. "
-                "Using 76 slices instead.") in caplog.text
+        assert (
+            "nslices is greater than 30% of number of x pixels. "
+            "Using 76 slices instead."
+        ) in caplog.text
 
     def test_tilt_com_no_slices_yes_nslices_too_big(self):
         stack = ds.get_needle_data()
@@ -108,13 +111,13 @@ class TestAlignFunctions:
 
     def test_calc_shifts_com_cl_res_error(self):
         stack = ds.get_needle_data()
-        with pytest.raises(ValueError,
-                           match="Resolution should be less than 0.5"):
+        with pytest.raises(ValueError, match="Resolution should be less than 0.5"):
             etspy.align.calc_shifts_com_cl(
                 stack,
                 com_ref_index=30,
                 cl_resolution=0.9,
             )
+
 
 @pytest.mark.skipif(not cupy_in_test_env, reason="cupy not available")
 class TestCUDAAlignFunctions:
@@ -131,6 +134,7 @@ class TestCUDAAlignFunctions:
             assert not etspy.align.has_cupy
         reload(sys.modules["etspy.align"])
         assert etspy.align.has_cupy
+
 
 class TestAlignStackRegister:
     """Test alignment using stack reg."""
@@ -203,14 +207,14 @@ class TestAlignStackRegister:
         """
         stack = ds.get_needle_data()
         bad_method = "WRONG"
-        with pytest.raises(ValueError,
-                           match=f"Invalid alignment method {bad_method}"):
+        with pytest.raises(ValueError, match=f"Invalid alignment method {bad_method}"):
             etspy.align.align_stack(
                 stack,
-                method=bad_method, # pyright: ignore[reportArgumentType]
+                method=bad_method,  # pyright: ignore[reportArgumentType]
                 start=None,
                 show_progressbar=False,
             )
+
 
 class TestTiltAlign:
     """Test tilt alignment functions."""
@@ -236,14 +240,14 @@ class TestTiltAlign:
         with pytest.raises(
             ValueError,
             match=r"Tilts are not defined in stack.tilts \(values were all zeros\). "
-                  r"Please set tilt values before alignment.",
+            r"Please set tilt values before alignment.",
         ):
             reg.tilt_align(method="CoM", slices=np.array([64, 128, 192]))
 
     def test_tilt_align_maximage(self):
         stack = ds.get_needle_data()
         stack = stack.inav[0:5]
-        reg = stack.stack_register("PC")
+        reg = stack.stack_register("PC", shift_type="interp")
         assert reg.metadata.get_item("Tomography.tiltaxis") == 0
         ali = reg.tilt_align(method="MaxImage")
         tilt_axis = ali.metadata.get_item("Tomography.tiltaxis")
@@ -262,7 +266,7 @@ class TestTiltAlign:
     def test_tilt_align_maximage_also_shift(self):
         stack = ds.get_needle_data()
         stack = stack.inav[0:5]
-        reg = stack.stack_register("PC")
+        reg = stack.stack_register("PC", shift_type="interp")
         assert reg.metadata.get_item("Tomography.tiltaxis") == 0
         ali = reg.tilt_align(method="MaxImage", also_shift=True)
         tilt_axis = ali.metadata.get_item("Tomography.tiltaxis")

--- a/etspy/tests/test_cuda.py
+++ b/etspy/tests/test_cuda.py
@@ -200,6 +200,7 @@ class TestStackRegisterCUDA:
         )
 
 
+@pytest.mark.skipif(not astra.use_cuda(), reason="CUDA not detected")
 class TestApplyShiftsCUDA:
     """Test StackReg alignment of a TomoStack using CUDA."""
 


### PR DESCRIPTION
Previously, all image shifts were applied using `scipy.ndimage.shift` which uses a spline interpolation approach.  This PR adds a Fourier shift option which is often preferred due to interpolation artifacts in the former approach.  The shifts in this case are implemented using `scipy.ndimage.fourier_shift` in a similar fashion to the interpolation option.  The following changes have been made:

* Added `method` parameter to `align.apply_shifts` which accepts either `"interp"` or `"fourier"` as options
* Implemented Fourier shift application in `align.apply_shifts`
* Added `shift_type` parameter to `base.TomoStack.stack_register` and `base.TomoStack.align_other` which accepts either `"interp"` or `"fourier"` as options
* Made `"fourier"` option the default
* Enabled CUDA acceleration for both image shift methods
* Added tests for new functionality