### PR TITLE
Fix remove ffmpeg dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,11 +59,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           with-cuda: true
           poetry-options: "--with=dev --without=gpu"
-      - name: Install ffmpeg
-        uses: Wandalen/wretry.action@master
-        with:
-          action: FedericoCarboni/setup-ffmpeg@v3
-          attempt_limit: 3
       - name: Run docstring example tests
         run: poetry run pytest --doctest-modules --ignore=etspy/tests etspy/ 
       - name: Run full test suite

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -10,7 +10,7 @@ import logging
 from abc import ABC
 from pathlib import Path
 from types import FrameType
-from typing import Dict, Iterable, List, Literal, Optional, Tuple, Union, cast
+from typing import Dict, List, Literal, Optional, Tuple, Union, cast
 
 try:
     from typing import Self  # type: ignore

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -27,8 +27,6 @@ from hyperspy._signals.signal2d import Signal2D
 from hyperspy.axes import UniformDataAxis as Uda
 from hyperspy.misc.utils import DictionaryTreeBrowser as Dtb
 from hyperspy.signal import BaseSignal, SpecialSlicersSignal
-from matplotlib import animation
-from matplotlib.artist import Artist
 from matplotlib.figure import Figure
 from scipy import ndimage
 from skimage import transform

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -82,22 +82,6 @@ class TestCommonStack:
             shifts = h5.get("/Experiments/__unnamed__/metadata/Tomography/_sig_shifts")
             assert shifts.get("data").shape == (77, 2)  # type: ignore
 
-    @pytest.mark.parametrize("axis", [("XY", 77), ("XZ", 256), ("YZ", 256)])
-    def test_save_movie(self, tmp_path, axis):
-        s = ds.get_needle_data(aligned=True)
-        f = tmp_path / f"output_movie_{axis[0]}.avi"
-        s.save_movie(start=0, stop=axis[1], outfile=f, axis=axis[0])
-
-    def test_save_movie_invalid_axis(self):
-        s = ds.get_needle_data(aligned=True)
-        with pytest.raises(
-            ValueError,
-            match=re.escape(
-                'Invalid axis "not valid". Must be one of ["XY", "YZ", or "XZ"].',
-            ),
-        ):
-            s.save_movie(start=0, stop=100, outfile="", axis="not valid")  # type: ignore
-
     def test_save_raw(self, tmp_path):
         os.chdir(tmp_path)
         s = ds.get_needle_data()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1144,14 +1144,13 @@ numpy = "*"
 pillow = ">=8.3.2"
 
 [package.extras]
-all-plugins = ["astropy", "av", "imageio-ffmpeg", "numpy (>2)", "pillow-heif", "psutil", "rawpy", "tifffile"]
-all-plugins-pypy = ["av", "imageio-ffmpeg", "pillow-heif", "psutil", "tifffile"]
+all-plugins = ["astropy", "av", "numpy (>2)", "pillow-heif", "psutil", "rawpy", "tifffile"]
+all-plugins-pypy = ["av", "pillow-heif", "psutil", "tifffile"]
 build = ["wheel"]
 dev = ["black", "flake8", "fsspec[github]", "pytest", "pytest-cov"]
 docs = ["numpydoc", "pydata-sphinx-theme", "sphinx (<6)"]
-ffmpeg = ["imageio-ffmpeg", "psutil"]
 fits = ["astropy"]
-full = ["astropy", "av", "black", "flake8", "fsspec[github]", "gdal", "imageio-ffmpeg", "itk", "numpy (>2)", "numpydoc", "pillow-heif", "psutil", "pydata-sphinx-theme", "pytest", "pytest-cov", "rawpy", "sphinx (<6)", "tifffile", "wheel"]
+full = ["astropy", "av", "black", "flake8", "fsspec[github]", "gdal", "itk", "numpy (>2)", "numpydoc", "pillow-heif", "psutil", "pydata-sphinx-theme", "pytest", "pytest-cov", "rawpy", "sphinx (<6)", "tifffile", "wheel"]
 gdal = ["gdal"]
 itk = ["itk"]
 linting = ["black", "flake8"]

--- a/resources/etspy-dev.yml
+++ b/resources/etspy-dev.yml
@@ -11,7 +11,6 @@ dependencies:
   - numba
   - numpy
   - pystackreg
-  - ffmpeg
   - pip
   - isort
   - myst-nb

--- a/resources/etspy-gpu-dev.yml
+++ b/resources/etspy-gpu-dev.yml
@@ -12,7 +12,6 @@ dependencies:
   - numba
   - numpy
   - pystackreg
-  - ffmpeg
   - pip
   - isort
   - myst-nb

--- a/resources/etspy-gpu.yml
+++ b/resources/etspy-gpu.yml
@@ -6,7 +6,6 @@ dependencies:
 # ensure that cuda version of astra gets installed
   - astra-toolbox>=2.1=*cuda*
   - cupy
-  - ffmpeg
   - hyperspy-base
   - hyperspy-gui-ipywidgets
   - ipykernel

--- a/resources/etspy.yml
+++ b/resources/etspy.yml
@@ -5,7 +5,6 @@ channels:
   - conda-forge
 dependencies:
   - astra-toolbox>=2.1
-  - ffmpeg
   - hyperspy-base
   - hyperspy-gui-ipywidgets
   - ipykernel


### PR DESCRIPTION
The `CommonStack.save_movie` functionality is now mostly unnecessary since interactive plotting is possible within notebooks.  Since there are also licensing issues with `ffmpeg` it is recommended to remove this method and the `ffmpeg` dependency.  

This also addresses #25.