### PR TITLE
Fixed many ruff formatting errors.

### DIFF
--- a/etspy/__init__.py
+++ b/etspy/__init__.py
@@ -1,10 +1,11 @@
 """ETSpy."""
+
 import importlib.metadata
 
 __version__ = importlib.metadata.version("etspy")
 
 from enum import Enum
-from typing import Callable, List, Literal, Union, get_args, get_type_hints
+from typing import Callable, Literal, Union, get_args, get_type_hints
 
 
 class AlignmentMethod(str, Enum):
@@ -41,7 +42,7 @@ class AlignmentMethod(str, Enum):
             return True
 
     @classmethod
-    def values(cls) -> List[str]:
+    def values(cls) -> list[str]:
         """Calculate a list of allowed values in the AlignmentMethod enum."""
         return [v.value for _, v in cls.__members__.items()]
 

--- a/etspy/api.py
+++ b/etspy/api.py
@@ -16,9 +16,9 @@ logger.setLevel(logging.INFO)
 etspy_path = _Path(__file__).parent
 
 __all__ = [
+    "TomoStack",
     "align",
     "io",
-    "utils",
-    "TomoStack",
     "load",
+    "utils",
 ]

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -9,8 +9,7 @@ import inspect
 import logging
 from abc import ABC
 from pathlib import Path
-from types import FrameType
-from typing import Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Literal, Optional, Union, cast
 
 try:
     from typing import Self  # type: ignore
@@ -24,8 +23,6 @@ import numpy as np
 import pylab as plt
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy._signals.signal2d import Signal2D
-from hyperspy.axes import UniformDataAxis as Uda
-from hyperspy.misc.utils import DictionaryTreeBrowser as Dtb
 from hyperspy.signal import BaseSignal, SpecialSlicersSignal
 from matplotlib.figure import Figure
 from scipy import ndimage
@@ -36,6 +33,12 @@ from etspy import AlignmentMethod, AlignmentMethodType, FbpMethodType, ReconMeth
 from etspy import _format_choices as _fmt
 from etspy import _get_literal_hint_values as _get_lit
 from etspy import align, recon
+
+if TYPE_CHECKING:
+    from types import FrameType
+
+    from hyperspy.axes import UniformDataAxis as Uda
+    from hyperspy.misc.utils import DictionaryTreeBrowser as Dtb
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -166,8 +169,8 @@ class TomoShifts(Signal1D):
 
     def _slicer(self, slices, isNavigation=None, out=None):  # noqa: N803
         if not isNavigation:
-            f = cast(FrameType, inspect.currentframe())
-            co_names = cast(FrameType, f.f_back).f_code.co_names
+            f = cast("FrameType", inspect.currentframe())
+            co_names = cast("FrameType", f.f_back).f_code.co_names
             if "_additional_slicing_targets" not in co_names:
                 # '_additional_slicing_targets' will only be present if call originated
                 # from the HyperSpy slicing module, meaning we reached this code by
@@ -241,8 +244,8 @@ class TomoTilts(Signal1D):
 
     def _slicer(self, slices, isNavigation=None, out=None):  # noqa: N803
         if not isNavigation:
-            f = cast(FrameType, inspect.currentframe())
-            co_names = cast(FrameType, f.f_back).f_code.co_names
+            f = cast("FrameType", inspect.currentframe())
+            co_names = cast("FrameType", f.f_back).f_code.co_names
             if "_additional_slicing_targets" not in co_names:
                 # '_additional_slicing_targets' will only be present if call originated
                 # from the HyperSpy slicing module, meaning we reached this code by
@@ -437,7 +440,7 @@ class CommonStack(Signal2D, ABC):
         datashape = self.data.shape
 
         if filename is None:
-            filename = Path(str(cast(Dtb, self.metadata.General).title))
+            filename = Path(str(cast("Dtb", self.metadata.General).title))
         elif isinstance(filename, str):
             filename = Path(filename)
 
@@ -544,11 +547,11 @@ class CommonStack(Signal2D, ABC):
                 order=interpolation_order,
             )
 
-        trans_tomo_meta = cast(Dtb, transformed.metadata.Tomography)
-        self_tomo_meta = cast(Dtb, self.metadata.Tomography)
-        trans_tomo_meta.xshift = cast(float, self_tomo_meta.xshift) + xshift
-        trans_tomo_meta.yshift = cast(float, self_tomo_meta.yshift) + yshift
-        trans_tomo_meta.tiltaxis = cast(float, self_tomo_meta.tiltaxis) + angle
+        trans_tomo_meta = cast("Dtb", transformed.metadata.Tomography)
+        self_tomo_meta = cast("Dtb", self.metadata.Tomography)
+        trans_tomo_meta.xshift = cast("float", self_tomo_meta.xshift) + xshift
+        trans_tomo_meta.yshift = cast("float", self_tomo_meta.yshift) + yshift
+        trans_tomo_meta.tiltaxis = cast("float", self_tomo_meta.tiltaxis) + angle
         return transformed
 
 
@@ -629,7 +632,7 @@ class TomoStack(CommonStack):
         )
 
     def _fix_projection_axis(self, axis_number: int):
-        ax = cast(Uda, self.axes_manager[axis_number])
+        ax = cast("Uda", self.axes_manager[axis_number])
         if ax.name in (Undefined, "z"):
             ax.name = "Projections"
         if ax.units == Undefined:
@@ -637,7 +640,7 @@ class TomoStack(CommonStack):
             del ax.scale
 
     def _fix_frames_axis(self, axis_number: int):
-        ax = cast(Uda, self.axes_manager[axis_number])
+        ax = cast("Uda", self.axes_manager[axis_number])
         if ax.name in (Undefined, "z"):
             ax.name = "Frames"
         if ax.units == Undefined:
@@ -664,7 +667,7 @@ class TomoStack(CommonStack):
             **kwargs,
         )
         self.metadata.add_node("Tomography")
-        cast(Dtb, self.metadata.Tomography).add_dictionary(tomo_metadata)
+        cast("Dtb", self.metadata.Tomography).add_dictionary(tomo_metadata)
 
         # need to handle navigation_dimension == 1 (normal case) or == 2 (multiframe)
         if self.axes_manager.navigation_dimension == 0:
@@ -684,7 +687,7 @@ class TomoStack(CommonStack):
             )
             raise ValueError(msg)
 
-        signal_axes = cast(tuple[Uda, Uda], self.axes_manager.signal_axes)
+        signal_axes = cast("tuple[Uda, Uda]", self.axes_manager.signal_axes)
         x_axis = signal_axes[0]
         x_axis.name = "x"
         if x_axis.units == Undefined:
@@ -757,13 +760,13 @@ class TomoStack(CommonStack):
                     or self.axes_manager.navigation_axes[0].units == ""
                 )
             ):
-                nav_ax_0 = cast(Uda, self.axes_manager.navigation_axes[0])
+                nav_ax_0 = cast("Uda", self.axes_manager.navigation_axes[0])
                 nav_ax_0.name = "Projections"
                 nav_ax_0.units = "degrees"
             # multiframe (special SerialEM case)
             elif self.axes_manager.navigation_dimension == 2:  # noqa: PLR2004
-                nav_ax_0 = cast(Uda, self.axes_manager.navigation_axes[0])
-                nav_ax_1 = cast(Uda, self.axes_manager.navigation_axes[1])
+                nav_ax_0 = cast("Uda", self.axes_manager.navigation_axes[0])
+                nav_ax_1 = cast("Uda", self.axes_manager.navigation_axes[1])
                 nav_ax_0.name = (
                     "Frames" if nav_ax_0.name == Undefined else nav_ax_0.name
                 )
@@ -777,8 +780,8 @@ class TomoStack(CommonStack):
                     "degrees" if nav_ax_1.units == Undefined else nav_ax_1.units
                 )
         if self.axes_manager.signal_axes:
-            cast(Uda, self.axes_manager.signal_axes[0]).name = "x"
-            cast(Uda, self.axes_manager.signal_axes[1]).name = "y"
+            cast("Uda", self.axes_manager.signal_axes[0]).name = "x"
+            cast("Uda", self.axes_manager.signal_axes[1]).name = "y"
 
         # ensure that shifts and tilts will be sliced when the Signal is
         self._additional_slicing_targets = [
@@ -874,12 +877,12 @@ class TomoStack(CommonStack):
         else:
             # value is already a Signal, so test the dimensions
             value = cast(
-                Union[TomoTilts, TomoShifts],
+                "Union[TomoTilts, TomoShifts]",
                 self._check_array_shape(value, mode),
             )
             # Using the TomoTilts/TomoShifts constructor strips metadata and axis
             # info, so copy it back:
-            target = cast(Union[TomoTilts, TomoShifts], _cls(data=value))
+            target = cast("Union[TomoTilts, TomoShifts]", _cls(data=value))
             target.metadata.add_dictionary(value.metadata.as_dictionary())
             target.axes_manager.update_axes_attributes_from(
                 (*value.axes_manager.navigation_axes, *value.axes_manager.signal_axes),
@@ -921,14 +924,14 @@ class TomoStack(CommonStack):
     @shifts.setter
     def shifts(self, new_shifts: Optional[Union[TomoShifts, np.ndarray]]):
         self._shifts = cast(
-            TomoShifts,
+            "TomoShifts",
             self.shift_and_tilt_setter("shifts", new_shifts),
         )
 
     @shifts.deleter
     def shifts(self):
         self._shifts = cast(
-            TomoShifts,
+            "TomoShifts",
             self.shift_and_tilt_setter("shifts", np.zeros_like(self.shifts.data)),
         )
 
@@ -946,14 +949,14 @@ class TomoStack(CommonStack):
     @tilts.setter
     def tilts(self, new_tilts: Optional[Union[TomoTilts, np.ndarray]]):
         self._tilts = cast(
-            TomoTilts,
+            "TomoTilts",
             self.shift_and_tilt_setter("tilts", new_tilts),
         )
 
     @tilts.deleter
     def tilts(self):
         self._tilts = cast(
-            TomoTilts,
+            "TomoTilts",
             self.shift_and_tilt_setter("tilts", np.zeros_like(self.tilts.data)),
         )
 
@@ -996,7 +999,7 @@ class TomoStack(CommonStack):
         s.shifts = copy.copy(self.shifts)
         return s
 
-    def plot_sinos(self, *args: Tuple, **kwargs: Dict):
+    def plot_sinos(self, *args: tuple, **kwargs: dict):
         """
         Plot the TomoStack in sinogram orientation.
 
@@ -1018,7 +1021,7 @@ class TomoStack(CommonStack):
             **kwargs,
         )
 
-    def remove_projections(self, projections: Optional[List] = None) -> "TomoStack":
+    def remove_projections(self, projections: Optional[list] = None) -> "TomoStack":
         """
         Return a copy of the TomoStack with certain projections removed from the series.
 
@@ -1046,9 +1049,9 @@ class TomoStack(CommonStack):
             raise ValueError(msg)
         nprojs = len(projections)
         s_new = self.deepcopy()
-        s_ax = cast(Uda, s_new.axes_manager[0])
-        s_tilt_ax = cast(Uda, s_new.tilts.axes_manager[0])
-        s_shift_ax = cast(Uda, s_new.shifts.axes_manager[0])
+        s_ax = cast("Uda", s_new.axes_manager[0])
+        s_tilt_ax = cast("Uda", s_new.tilts.axes_manager[0])
+        s_shift_ax = cast("Uda", s_new.shifts.axes_manager[0])
         for ax in (s_ax, s_tilt_ax, s_shift_ax):
             ax.size -= nprojs
         mask = np.ones(self.data.shape[0], dtype=bool)
@@ -1086,7 +1089,7 @@ class TomoStack(CommonStack):
 
     def test_correlation(
         self,
-        images: Optional[Union[List[int], Tuple[int, int]]] = None,
+        images: Optional[Union[list[int], tuple[int, int]]] = None,
     ) -> Figure:
         """
         Test output of cross-correlation prior to alignment.
@@ -1161,7 +1164,7 @@ class TomoStack(CommonStack):
         """
         # Check if any transformations have been applied to the current stack
         no_shifts = np.all(self.shifts.data == 0)
-        tomo_meta = cast(Dtb, self.metadata.Tomography)
+        tomo_meta = cast("Dtb", self.metadata.Tomography)
         no_xshift = any(
             [
                 tomo_meta.xshift is None,
@@ -1282,7 +1285,7 @@ class TomoStack(CommonStack):
         start: Optional[int] = None,
         show_progressbar: bool = False,
         crop: bool = False,
-        xrange: Optional[Tuple[int, int]] = None,
+        xrange: Optional[tuple[int, int]] = None,
         p: int = 20,
         nslices: int = 20,
         com_ref_index: Optional[int] = None,
@@ -1526,7 +1529,7 @@ class TomoStack(CommonStack):
         ncores: Optional[int] = None,
         sino_filter: FbpMethodType = "shepp-logan",
         dart_iterations: Optional[int] = 5,
-        gray_levels: Optional[Union[List, np.ndarray]] = None,
+        gray_levels: Optional[Union[list, np.ndarray]] = None,
     ) -> "RecStack":
         """
         Reconstruct a TomoStack series using one of the available methods.
@@ -1659,7 +1662,7 @@ class TomoStack(CommonStack):
             ncores=ncores,
             bp_filter=sino_filter,
             gray_levels=gray_levels,
-            dart_iterations=cast(int, dart_iterations),
+            dart_iterations=cast("int", dart_iterations),
             p=p,
             show_progressbar=show_progressbar,
         )
@@ -1740,10 +1743,13 @@ class TomoStack(CommonStack):
             shifted = self.trans_stack(xshift=0, yshift=tilt_shift, angle=tilt_rotation)
         else:
             shifted = self.deepcopy()
-        shifted = cast(TomoStack, shifted)
+        shifted = cast("TomoStack", shifted)
         shifted.data = shifted.data[:, :, slices]
 
-        cast(Uda, shifted.axes_manager[0]).axis = cast(Uda, self.axes_manager[0]).axis
+        cast("Uda", shifted.axes_manager[0]).axis = cast(
+            "Uda",
+            self.axes_manager[0],
+        ).axis
         if cuda is None:
             if astra.use_cuda():  # coverage: nocuda
                 logger.info("CUDA detected with Astra")
@@ -1799,7 +1805,7 @@ class TomoStack(CommonStack):
             Tilt increment between images
         """
         nimages = self.data.shape[0]
-        ax = cast(Uda, self.axes_manager[0])
+        ax = cast("Uda", self.axes_manager[0])
         ax.name = "Projections"
         ax.units = "degrees"
         ax.scale = increment
@@ -1808,7 +1814,7 @@ class TomoStack(CommonStack):
 
         if not self.metadata.has_item("Tomography"):
             self.metadata.add_node("Tomography")
-            tomo_meta = cast(Dtb, self.metadata.Tomography)
+            tomo_meta = cast("Dtb", self.metadata.Tomography)
             tomo_meta.set_item("tiltaxis", 0)
             tomo_meta.set_item("xshift", 0)
             tomo_meta.set_item("yshift", 0)
@@ -1909,7 +1915,7 @@ class TomoStack(CommonStack):
         constrain: bool = True,
         cuda: Optional[bool] = None,
         thresh: float = 0,
-    ) -> Tuple[Signal2D, Signal1D]:
+    ) -> tuple[Signal2D, Signal1D]:
         """
         Determine the optimum number of iterations for reconstruction.
 
@@ -1975,9 +1981,9 @@ class TomoStack(CommonStack):
         )
         rec_stack = Signal2D(rec_stack)
         rec_ax0, rec_ax1, rec_ax2 = (
-            cast(Uda, rec_stack.axes_manager[i]) for i in range(3)
+            cast("Uda", rec_stack.axes_manager[i]) for i in range(3)
         )
-        self_ax2 = cast(Uda, self.axes_manager[2])
+        self_ax2 = cast("Uda", self.axes_manager[2])
         rec_ax0.name = algorithm.upper() + " iteration"
         rec_ax0.scale = 1
         rec_ax1.name = self_ax2.name
@@ -1989,8 +1995,8 @@ class TomoStack(CommonStack):
         rec_stack.navigator = "slider"
 
         error = Signal1D(error)
-        cast(Uda, error.axes_manager[0]).name = algorithm.upper() + " Iteration"
-        cast(Dtb, error.metadata.Signal).quantity = "Sum of Squared Difference"
+        cast("Uda", error.axes_manager[0]).name = algorithm.upper() + " Iteration"
+        cast("Dtb", error.metadata.Signal).quantity = "Sum of Squared Difference"
         return rec_stack, error
 
     def extract_sinogram(
@@ -2036,7 +2042,7 @@ class TomoStack(CommonStack):
         try:
             sino = self.isig[column, :]
             sino.set_signal_type("")
-            sino = cast(Signal2D, sino.as_signal2D((2, 0)))
+            sino = cast("Signal2D", sino.as_signal2D((2, 0)))
             if isinstance(column, float):
                 title = f"Sinogram at x = {column} {self.axes_manager[1].units}"  # type: ignore
             else:

--- a/etspy/io.py
+++ b/etspy/io.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, List, Optional, Tuple, Union, cast
+from typing import Any, Optional, Union, cast
 
 import numpy as np
 from hyperspy._signals.signal2d import (
@@ -56,7 +56,7 @@ def get_mrc_tilts(
     tiltfile = filename.with_suffix(".rawtlt")
     tilts = None
     if stack.original_metadata.has_item("fei_header"):
-        fei_header = cast(Dtb, stack.original_metadata.fei_header)
+        fei_header = cast("Dtb", stack.original_metadata.fei_header)
         if fei_header.has_item("a_tilt"):
             tilts = fei_header["a_tilt"][0 : stack.data.shape[0]]
             logger.info("Tilts found in MRC file header")
@@ -114,7 +114,7 @@ def get_dm_tilts(s: Union[Signal2D, TomoStack]) -> np.ndarray:
 def parse_mdoc(
     mdoc_file: PathLike,
     series: bool = False,
-) -> Tuple[dict, Union[np.ndarray, float]]:
+) -> tuple[dict, Union[np.ndarray, float]]:
     """Parse experimental parameters from a SerialEM MDOC file.
 
     Parameters
@@ -223,9 +223,9 @@ def load_serialem(mrcfile: PathLike, mdocfile: PathLike) -> TomoStack:
 
 
 def load_serialem_series(
-    mrcfiles: Union[List[str], List[Path]],
-    mdocfiles: Union[List[str], List[Path]],
-) -> Tuple[Signal2D, np.ndarray]:
+    mrcfiles: Union[list[str], list[Path]],
+    mdocfiles: Union[list[str], list[Path]],
+) -> tuple[Signal2D, np.ndarray]:
     """
     Load a multi-frame series collected by SerialEM.
 
@@ -424,9 +424,9 @@ def _load_single_file(filename: Path) -> TomoStack:
 
 
 def load(
-    filename: Union[PathLike, List[str], List[Path]],
-    tilts: Optional[Union[List[float], np.ndarray]] = None,
-    mdocs: Optional[Union[List[str], List[Path]]] = None,
+    filename: Union[PathLike, list[str], list[Path]],
+    tilts: Optional[Union[list[float], np.ndarray]] = None,
+    mdocs: Optional[Union[list[str], list[Path]]] = None,
 ) -> TomoStack:
     """
     Create a TomoStack object using data from a file.

--- a/etspy/recon.py
+++ b/etspy/recon.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import copy
 import logging
 import multiprocessing as mp
-from typing import Literal, Optional, Union, cast
+from typing import Literal, Union, cast
 
 import astra
 import numpy as np
@@ -172,9 +172,9 @@ def run(  # noqa: PLR0912, PLR0913, PLR0915
     niterations: int = 20,
     constrain: bool = False,
     thresh: float = 0,
-    cuda: Optional[bool] = None,
-    thickness: Optional[int] = None,
-    ncores: Optional[int] = None,
+    cuda: bool | None = None,
+    thickness: int | None = None,
+    ncores: int | None = None,
     bp_filter: Literal[
         "ram-lak",
         "shepp-logan",
@@ -199,7 +199,7 @@ def run(  # noqa: PLR0912, PLR0913, PLR0915
         "rprojection",
         "rsinogram",
     ] = "shepp-logan",
-    gray_levels: Optional[Union[list, np.ndarray]] = None,
+    gray_levels: Union[list, np.ndarray] | None = None,
     dart_iterations: int = 2,
     p: float = 0.99,
     show_progressbar: bool = True,
@@ -269,7 +269,7 @@ def run(  # noqa: PLR0912, PLR0913, PLR0915
 
     if thickness is None:
         thickness = ny
-    thickness = cast(int, thickness)
+    thickness = cast("int", thickness)
 
     rec = np.zeros((nx, thickness, ny), np.float32)
 
@@ -310,7 +310,7 @@ def run(  # noqa: PLR0912, PLR0913, PLR0915
             if gray_levels is None:
                 msg = "gray_levels must be provided for DART"
                 raise ValueError(msg)
-            gray_levels = cast(Union[list, np.ndarray], gray_levels)
+            gray_levels = cast("Union[list, np.ndarray]", gray_levels)
             thresholds = [
                 (gray_levels[i] + gray_levels[i + 1]) // 2
                 for i in range(len(gray_levels) - 1)
@@ -342,7 +342,7 @@ def run(  # noqa: PLR0912, PLR0913, PLR0915
                     dart_iterations,
                     p,
                     thresholds,
-                    cast(Union[list, np.ndarray], gray_levels),
+                    cast("Union[list, np.ndarray]", gray_levels),
                     cfg,
                     vol_geom,
                     proj_geom,
@@ -375,7 +375,7 @@ def run(  # noqa: PLR0912, PLR0913, PLR0915
             if gray_levels is None:
                 msg = "gray_levels must be provided for DART"
                 raise ValueError(msg)
-            gray_levels = cast(np.ndarray, gray_levels)  # explicit type-checking cast
+            gray_levels = cast("np.ndarray", gray_levels)  # explicit type-checking cast
             thresholds = [
                 (gray_levels[i] + gray_levels[i + 1]) // 2
                 for i in range(len(gray_levels) - 1)

--- a/etspy/simulation.py
+++ b/etspy/simulation.py
@@ -1,6 +1,6 @@
 """Simulation module for ETSpy package."""
 
-from typing import Literal, Optional, Tuple, Union, cast
+from typing import Literal, Optional, Union, cast
 
 import astra
 import hyperspy.api as hs
@@ -17,9 +17,9 @@ def create_catalyst_model(
     nparticles: int = 15,
     particle_density: int = 255,
     support_density: int = 100,
-    volsize: Tuple[int, int, int] = (600, 600, 600),
+    volsize: tuple[int, int, int] = (600, 600, 600),
     support_radius: int = 200,
-    size_interval: Tuple[int, int] = (5, 12),
+    size_interval: tuple[int, int] = (5, 12),
 ) -> hs.signals.Signal2D:
     """
     Create a model data array that mimics a hetergeneous catalyst.
@@ -219,7 +219,7 @@ def create_model_tilt_series(
 
     if angles is None:
         angles = np.arange(0, 180, 2)
-    angles = cast(np.ndarray, angles)
+    angles = cast("np.ndarray", angles)
 
     if isinstance(model, Signal2D):
         model = model.data
@@ -235,7 +235,11 @@ def create_model_tilt_series(
     if cuda is False:
         proj_id = astra.create_projector("linear", proj_geom, vol_geom)
     else:
-        proj_id = astra.create_projector("cuda", proj_geom, vol_geom) # coverage: nocuda
+        proj_id = astra.create_projector(
+            "cuda",
+            proj_geom,
+            vol_geom,
+        )  # coverage: nocuda
 
     for i in range(model.shape[0]):
         sino_id, proj_data[:, :, i] = astra.create_sino(model[i, :, :], proj_id)

--- a/etspy/tests/test_align.py
+++ b/etspy/tests/test_align.py
@@ -4,15 +4,17 @@ import re
 import sys
 from importlib import reload
 from importlib.util import find_spec
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
 import numpy as np
 import pytest
-from hyperspy.misc.utils import DictionaryTreeBrowser as Dtb
 
 import etspy.api as etspy
 from etspy import datasets as ds
+
+if TYPE_CHECKING:
+    from hyperspy.misc.utils import DictionaryTreeBrowser as Dtb
 
 cupy_in_test_env = find_spec("cupy") is not None
 
@@ -103,8 +105,7 @@ class TestAlignFunctions:
         with pytest.raises(
             ValueError,
             match=(
-                "Dataset is only 2 pixels in x dimension. "
-                "This method cannot be used."
+                "Dataset is only 2 pixels in x dimension. This method cannot be used."
             ),
         ):
             etspy.align.tilt_com(stack)
@@ -223,15 +224,15 @@ class TestTiltAlign:
         stack = ds.get_needle_data()
         reg = stack.stack_register("PC")
         ali = reg.tilt_align(method="CoM", slices=np.array([64, 128, 192]))
-        tilt_axis = cast(Dtb, ali.metadata.Tomography).tiltaxis
-        assert abs(-2.7 - cast(float, tilt_axis)) < 1.0
+        tilt_axis = cast("Dtb", ali.metadata.Tomography).tiltaxis
+        assert abs(-2.7 - cast("float", tilt_axis)) < 1.0
 
     def test_tilt_align_com_no_locs(self):
         stack = ds.get_needle_data()
         reg = stack.stack_register("PC")
         ali = reg.tilt_align(method="CoM", slices=None, nslices=None)
-        tilt_axis = cast(Dtb, ali.metadata.Tomography).tiltaxis
-        assert abs(-2.7 - cast(float, tilt_axis)) < 1.0
+        tilt_axis = cast("Dtb", ali.metadata.Tomography).tiltaxis
+        assert abs(-2.7 - cast("float", tilt_axis)) < 1.0
 
     def test_tilt_align_com_no_tilts(self):
         stack = ds.get_needle_data()
@@ -325,7 +326,7 @@ class TestAlignOther:
         stack = stack.inav[0:5]
         stack2 = stack.deepcopy()
         reg = stack.stack_register("PC")
-        reg = cast(etspy.TomoStack, reg.trans_stack(xshift=10, yshift=5, angle=2))
+        reg = cast("etspy.TomoStack", reg.trans_stack(xshift=10, yshift=5, angle=2))
         reg2 = reg.align_other(stack2)
         diff = reg.data - reg2.data
         assert diff.sum() == 0.0

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -6,7 +6,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
 import astra
@@ -15,9 +15,7 @@ import hyperspy.api as hs
 import numpy as np
 import pytest
 from hyperspy._signals.signal2d import Signal2D
-from hyperspy.axes import UniformDataAxis as Uda
 from hyperspy.io import load as hs_load
-from hyperspy.misc.utils import DictionaryTreeBrowser
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
 
@@ -25,6 +23,10 @@ from etspy import datasets as ds
 from etspy.base import CommonStack, RecStack, TomoShifts, TomoStack, TomoTilts
 
 from . import load_serialem_multiframe_data
+
+if TYPE_CHECKING:
+    from hyperspy.axes import UniformDataAxis as Uda
+    from hyperspy.misc.utils import DictionaryTreeBrowser
 
 NUM_AXES_THREE = 3
 
@@ -38,7 +40,7 @@ def _set_tomo_metadata(s: Signal2D) -> Signal2D:
     }
     s.metadata.add_node("Tomography")
     cast(
-        DictionaryTreeBrowser,
+        "DictionaryTreeBrowser",
         s.metadata.Tomography,
     ).add_dictionary(tomo_metadata)
     return s
@@ -181,7 +183,7 @@ class TestTomoStack:
         assert stack.metadata.get_item("General.title") == "test signal"
 
     def test_tomostack_create_by_signal_original_metadata(self):
-        s = cast(Signal2D, hs.signals.Signal2D(np.random.random([10, 100, 100])))
+        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([10, 100, 100])))
         s.metadata.set_item("General.title", "original_metadata test")
         s.original_metadata.set_item("Level1.level2", "the value")
         stack = TomoStack(s)
@@ -189,7 +191,7 @@ class TestTomoStack:
         assert stack.original_metadata.get_item("Level1.level2") == "the value"
 
     def test_tomostack_create_by_signal_original_metadata_arg(self):
-        s = cast(Signal2D, hs.signals.Signal2D(np.random.random([10, 100, 100])))
+        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([10, 100, 100])))
         s.metadata.set_item("General.title", "original_metadata test")
         s.original_metadata.set_item("Level1.level2", "the value")
         stack = TomoStack(s, original_metadata={"A1": {"B1": "C", "B2": "C2"}})
@@ -199,7 +201,7 @@ class TestTomoStack:
         assert stack.original_metadata.get_item("A1.B2") == "C2"
 
     def test_tomostack_create_by_signal_axes(self):
-        s = cast(Signal2D, hs.signals.Signal2D(np.random.random([10, 100, 100])))
+        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([10, 100, 100])))
         s.axes_manager[0].name = "Test nav"  # type: ignore
         s.axes_manager[0].units = "Nav units"  # type: ignore
         stack = TomoStack(s)
@@ -207,7 +209,7 @@ class TestTomoStack:
         assert stack.axes_manager[0].units == "Nav units"  # type: ignore
 
     def test_tomostack_create_by_signal_axes_list_arg(self):
-        s = cast(Signal2D, hs.signals.Signal2D(np.random.random([10, 100, 100])))
+        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([10, 100, 100])))
         ax_list = [
             {
                 "_type": "UniformDataAxis",
@@ -247,7 +249,7 @@ class TestTomoStack:
         assert stack.axes_manager[-1].scale == 0.123  # type: ignore
 
     def test_tomostack_create_by_signal_undefined_axes(self):
-        s = cast(Signal2D, hs.signals.Signal2D(np.random.random([10, 100, 100])))
+        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([10, 100, 100])))
         axes = [
             {"size": 10, "name": "Axis0", "units": ""},
             {"size": 100, "name": "Axis1", "units": ""},
@@ -260,7 +262,7 @@ class TestTomoStack:
     def test_tomostack_create_by_array_multiframe(self):
         n = np.random.random([20, 5, 110, 120])
         stack = TomoStack(n)
-        ax0, ax1, ax2, ax3 = (cast(Uda, stack.axes_manager[i]) for i in range(4))
+        ax0, ax1, ax2, ax3 = (cast("Uda", stack.axes_manager[i]) for i in range(4))
         assert ax0.name == "Frames"
         assert ax1.name == "Projections"
         assert ax2.name == "x"
@@ -701,7 +703,10 @@ class TestSlicers:
         s = load_serialem_multiframe_data()
         assert s.axes_manager.shape == (2, 3, 1024, 1024)
         assert s.data.shape == (3, 2, 1024, 1024)
-        ax_0, ax_1, ax_2, ax_3 = cast(list[Uda], [s.axes_manager[i] for i in range(4)])
+        ax_0, ax_1, ax_2, ax_3 = cast(
+            "list[Uda]",
+            [s.axes_manager[i] for i in range(4)],
+        )
         assert ax_0.name == "Frames"
         assert ax_0.units == "images"
         assert ax_1.name == "Projections"
@@ -764,7 +769,7 @@ class TestSlicers:
             ) in caplog.text
         assert t.data.shape == (77, 256, 1)
         assert t.axes_manager.shape == (77, 1, 256)
-        ax_0, ax_1, ax_2 = cast(list[Uda], [t.axes_manager[i] for i in range(3)])
+        ax_0, ax_1, ax_2 = cast("list[Uda]", [t.axes_manager[i] for i in range(3)])
         assert ax_0.name == "Projections"
         assert ax_1.name == "x"
         assert ax_2.name == "y"
@@ -789,7 +794,7 @@ class TestSlicers:
             ) in caplog.text
         assert t.data.shape == (77, 1, 256)
         assert t.axes_manager.shape == (77, 256, 1)
-        ax_0, ax_1, ax_2 = cast(list[Uda], [t.axes_manager[i] for i in range(3)])
+        ax_0, ax_1, ax_2 = cast("list[Uda]", [t.axes_manager[i] for i in range(3)])
         assert ax_0.name == "Projections"
         assert ax_1.name == "x"
         assert ax_2.name == "y"
@@ -814,7 +819,7 @@ class TestSlicers:
             ) in caplog.text
         assert t.data.shape == (77, 1, 256)
         assert t.axes_manager.shape == (77, 256, 1)
-        ax_0, ax_1, ax_2 = cast(list[Uda], [t.axes_manager[i] for i in range(3)])
+        ax_0, ax_1, ax_2 = cast("list[Uda]", [t.axes_manager[i] for i in range(3)])
         assert ax_0.name == "Projections"
         assert ax_1.name == "x"
         assert ax_2.name == "y"
@@ -852,7 +857,7 @@ class TestExtractSinogram:
     def test_extract_sinogram(self):
         stack = ds.get_catalyst_data()
         sino = stack.extract_sinogram(300)
-        ax_0, ax_1 = cast(list[Uda], [sino.axes_manager[i] for i in range(2)])
+        ax_0, ax_1 = cast("list[Uda]", [sino.axes_manager[i] for i in range(2)])
         assert sino.axes_manager.shape == (600, 90)
         assert sino.metadata.get_item("Signal.signal_type") == ""
         assert ax_0.name == "y"
@@ -862,7 +867,7 @@ class TestExtractSinogram:
     def test_extract_sinogram_float(self):
         stack = ds.get_catalyst_data()
         sino = stack.extract_sinogram(106.32)
-        ax_0, ax_1 = cast(list[Uda], [sino.axes_manager[i] for i in range(2)])
+        ax_0, ax_1 = cast("list[Uda]", [sino.axes_manager[i] for i in range(2)])
         assert sino.axes_manager.shape == (600, 90)
         assert sino.metadata.get_item("Signal.signal_type") == ""
         assert ax_0.name == "y"
@@ -961,7 +966,7 @@ class TestOperations:
 
     def test_stack_normalize(self):
         stack = ds.get_needle_data()
-        norm = cast(TomoStack, stack.normalize())
+        norm = cast("TomoStack", stack.normalize())
         assert norm.axes_manager.navigation_shape == stack.axes_manager.navigation_shape
         assert norm.axes_manager.signal_shape == stack.axes_manager.signal_shape
         assert norm.data.min() == 0.0
@@ -970,7 +975,7 @@ class TestOperations:
         im = np.zeros([10, 100, 100])
         im[:, 40:60, 40:60] = 10
         stack = TomoStack(im)
-        invert = cast(TomoStack, stack.invert())
+        invert = cast("TomoStack", stack.invert())
         hist, bins = np.histogram(stack.data)
         hist_inv, bins_inv = np.histogram(invert.data)
         assert hist[0] > hist_inv[0]
@@ -992,7 +997,7 @@ class TestOperations:
         stack = ds.get_needle_data()
         start, increment = -50, 5
         stack.set_tilts(start, increment)
-        ax = cast(Uda, stack.axes_manager[0])
+        ax = cast("Uda", stack.axes_manager[0])
         assert ax.name == "Projections"
         assert ax.scale == increment
         assert ax.units == "degrees"
@@ -1011,7 +1016,7 @@ class TestOperations:
         del stack.metadata.Tomography  # pyright: ignore[reportAttributeAccessIssue]
         start, increment = -50, 5
         stack.set_tilts(start, increment)
-        ax = cast(Uda, stack.axes_manager[0])
+        ax = cast("Uda", stack.axes_manager[0])
         assert ax.name == "Projections"
         assert ax.scale == increment
         assert ax.units == "degrees"

--- a/etspy/tests/test_cuda.py
+++ b/etspy/tests/test_cuda.py
@@ -1,7 +1,7 @@
 """Tests for the CUDA-enabled functionality of ETSpy."""
 
 import re
-from typing import Tuple, cast
+from typing import cast
 
 import astra
 import matplotlib.pyplot as plt
@@ -138,7 +138,7 @@ class TestReconRunCUDA:
         slices = stack.isig[120:121, :].deepcopy()
         tilts = slices.tilts.data.squeeze()
         rec = recon.run(slices.data, tilts, "FBP", cuda=True)
-        data_shape = cast(Tuple[int, int, int], rec.data.shape)
+        data_shape = cast("tuple[int, int, int]", rec.data.shape)
         assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)
@@ -148,7 +148,7 @@ class TestReconRunCUDA:
         slices = stack.isig[120:121, :].deepcopy()
         tilts = slices.tilts.data.squeeze()
         rec = recon.run(slices.data, tilts, "SIRT", niterations=2, cuda=True)
-        data_shape = cast(Tuple[int, int, int], rec.data.shape)
+        data_shape = cast("tuple[int, int, int]", rec.data.shape)
         assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)
@@ -158,7 +158,7 @@ class TestReconRunCUDA:
         slices = stack.isig[120:121, :].deepcopy()
         tilts = slices.tilts.data.squeeze()
         rec = recon.run(slices.data, tilts, "SART", niterations=2, cuda=True)
-        data_shape = cast(Tuple[int, int, int], rec.data.shape)
+        data_shape = cast("tuple[int, int, int]", rec.data.shape)
         assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)
@@ -177,7 +177,7 @@ class TestReconRunCUDA:
             gray_levels=gray_levels,
             dart_iterations=1,
         )
-        data_shape = cast(Tuple[int, int, int], rec.data.shape)
+        data_shape = cast("tuple[int, int, int]", rec.data.shape)
         assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)

--- a/etspy/tests/test_io.py
+++ b/etspy/tests/test_io.py
@@ -1,6 +1,6 @@
 """Tests for the IO functionality of ETSpy."""
 
-from typing import List, cast
+from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
 import h5py
@@ -8,7 +8,6 @@ import hyperspy.api as hs
 import numpy as np
 import pytest
 from h5py import Dataset
-from hyperspy.axes import UniformDataAxis as Uda
 from hyperspy.io import load as hs_load
 
 import etspy.api as etspy
@@ -17,6 +16,9 @@ from etspy.base import MismatchedTiltError, TomoShifts, TomoStack, TomoTilts
 
 from . import hspy_mrc_reader_check, load_serialem_multiframe_data
 
+if TYPE_CHECKING:
+    from hyperspy.axes import UniformDataAxis as Uda
+
 try:
     hspy_mrc_reader_check()
 except TypeError:
@@ -24,9 +26,11 @@ except TypeError:
 else:
     hspy_mrc_broken = False
 
+
 def _type_error_mock(_, reader):  # noqa: ARG001
     msg = "Mocked type error for broken MRC reader"
     raise TypeError(msg)
+
 
 class TestLoadMRC:
     """Test loading an MRC file."""
@@ -35,7 +39,7 @@ class TestLoadMRC:
         filename = etspy_path / "tests" / "test_data" / "HAADF.mrc"
         stack_orig = hs_load(filename)
         stack = etspy.io.load(filename)
-        ax_list = cast(List[Uda], stack.axes_manager)
+        ax_list = cast("list[Uda]", stack.axes_manager)
 
         assert stack.axes_manager.signal_shape == (256, 256)
         assert stack.axes_manager.navigation_shape == (77,)
@@ -58,7 +62,7 @@ class TestLoadMRC:
         filename = etspy_path / "tests" / "test_data" / "HAADF.ali"
         stack_orig = hs_load(filename)
         stack = etspy.io.load(filename)
-        ax_list = cast(List[Uda], stack.axes_manager)
+        ax_list = cast("list[Uda]", stack.axes_manager)
 
         assert stack.axes_manager.signal_shape == (256, 256)
         assert stack.axes_manager.navigation_shape == (77,)
@@ -74,8 +78,8 @@ class TestLoadMRC:
     def test_load_mrc_with_rawtlt(self):
         filename = etspy_path / "tests" / "test_data" / "HAADF.mrc"
         stack = etspy.io.load(filename)
-        del stack.original_metadata.fei_header # pyright: ignore[reportAttributeAccessIssue]
-        del stack.original_metadata.std_header # pyright: ignore[reportAttributeAccessIssue]
+        del stack.original_metadata.fei_header  # pyright: ignore[reportAttributeAccessIssue]
+        del stack.original_metadata.std_header  # pyright: ignore[reportAttributeAccessIssue]
         tilts = etspy.io.get_mrc_tilts(stack, filename)
         assert isinstance(tilts, np.ndarray)
         assert tilts.shape[0] == stack.data.shape[0]
@@ -86,8 +90,8 @@ class TestLoadMRC:
     def test_load_mrc_with_rawtlt_str_filename(self):
         filename = etspy_path / "tests" / "test_data" / "HAADF.mrc"
         stack = etspy.io.load(str(filename))
-        del stack.original_metadata.fei_header # pyright: ignore[reportAttributeAccessIssue]
-        del stack.original_metadata.std_header # pyright: ignore[reportAttributeAccessIssue]
+        del stack.original_metadata.fei_header  # pyright: ignore[reportAttributeAccessIssue]
+        del stack.original_metadata.std_header  # pyright: ignore[reportAttributeAccessIssue]
         tilts = etspy.io.get_mrc_tilts(stack, str(filename))
         assert isinstance(tilts, np.ndarray)
         assert tilts.shape[0] == stack.data.shape[0]
@@ -98,8 +102,8 @@ class TestLoadMRC:
     def test_load_mrc_with_bad_rawtlt(self):
         filename = etspy_path / "tests" / "test_data" / "HAADF.mrc"
         stack = etspy.io.load(filename)
-        del stack.original_metadata.fei_header # pyright: ignore[reportAttributeAccessIssue]
-        del stack.original_metadata.std_header # pyright: ignore[reportAttributeAccessIssue]
+        del stack.original_metadata.fei_header  # pyright: ignore[reportAttributeAccessIssue]
+        del stack.original_metadata.std_header  # pyright: ignore[reportAttributeAccessIssue]
         stack.data = np.append(
             stack.data,
             np.zeros([1, stack.data.shape[1], stack.data.shape[2]]),
@@ -132,10 +136,10 @@ class TestHspy:
         filename = etspy_path / "tests" / "test_data" / "HAADF_Aligned.hdf5"
         stack_orig = hs_load(filename, reader="HSPY")
         stack = etspy.io.load(filename)
-        ax_list = cast(List[Uda], stack.axes_manager)
+        ax_list = cast("list[Uda]", stack.axes_manager)
         with h5py.File(filename, "r") as h5:
             h5_data = h5.get("/Experiments/__unnamed__/data")
-            h5_data = cast(Dataset, h5_data)  # cast for type-checking
+            h5_data = cast("Dataset", h5_data)  # cast for type-checking
             h5_shape = h5_data.shape
         assert stack.data.shape[1:] == h5_shape[1:]
         assert stack.data.shape[0] == h5_shape[0]
@@ -182,13 +186,14 @@ class TestNumpy:
         assert np.all(stack.tilts.data.squeeze() == np.arange(-50, 50, 2))
         assert stack.tilts.data.shape[0] == stack.data.shape[0]
 
+
 class TestSignal:
     """Test creating stacks from HyperSpy signals."""
 
     def test_signal_to_stack(self):
         signal = hs.signals.Signal2D(np.random.random([50, 100, 100]))
         stack = TomoStack(signal)
-        ax_list = cast(List[Uda], stack.axes_manager)
+        ax_list = cast("list[Uda]", stack.axes_manager)
         assert ax_list[0].name == "Projections"
         assert stack.axes_manager.signal_shape == (100, 100)
         assert stack.axes_manager.navigation_shape == (50,)
@@ -214,7 +219,7 @@ class TestDM:
         filename = etspy_path / "tests" / "test_data" / "HAADF.dm3"
         signal = hs_load(filename)
         stack = etspy.load(filename)
-        ax_list = cast(List[Uda], stack.axes_manager)
+        ax_list = cast("list[Uda]", stack.axes_manager)
         assert ax_list[0].name == "Projections"
         assert ax_list[0].units == "degrees"
         assert stack.axes_manager.signal_shape == (64, 64)
@@ -234,7 +239,7 @@ class TestDM:
         files = list(dirname.glob("*.dm3"))
         signal = hs_load(files, stack=True)
         stack = etspy.load(files)
-        ax_list = cast(List[Uda], stack.axes_manager)
+        ax_list = cast("list[Uda]", stack.axes_manager)
         assert ax_list[0].name == "Projections"
         assert ax_list[0].units == "degrees"
         assert ax_list[0].scale == pytest.approx(3, abs=0.1)
@@ -288,11 +293,13 @@ class TestSerialEM:
         assert stack.tilts.axes_manager.navigation_shape == (2, 3)
         assert np.allclose(
             stack.tilts.data,
-            np.array([
-                [[-5.00151e+00],[-5.00151e+00]],
-                [[-4.88000e-04],[-4.88000e-04]],
-                [[ 5.00054e+00],[ 5.00054e+00]],
-            ]),
+            np.array(
+                [
+                    [[-5.00151e00], [-5.00151e00]],
+                    [[-4.88000e-04], [-4.88000e-04]],
+                    [[5.00054e00], [5.00054e00]],
+                ],
+            ),
         )
         assert isinstance(stack.shifts, TomoShifts)
         assert stack.shifts.data.shape == (3, 2, 2)
@@ -366,7 +373,6 @@ class TestSerialEM:
         assert isinstance(stack, TomoStack)
         assert isinstance(stack.tilts, TomoTilts)
         assert isinstance(stack.shifts, TomoShifts)
-
 
 
 class TestUnknown:

--- a/etspy/tests/test_recon.py
+++ b/etspy/tests/test_recon.py
@@ -1,7 +1,7 @@
 """Test the reconstruction module of ETSpy."""
 
 import re
-from typing import Tuple, cast
+from typing import cast
 
 import astra
 import numpy as np
@@ -22,7 +22,7 @@ class TestReconstruction:
         with pytest.raises(
             ValueError,
             match=r"Tilts are not defined in stack.tilts \(values were all zeros\). "
-                  r"Please set tilt values before alignment.",
+            r"Please set tilt values before alignment.",
         ):
             slices.reconstruct("FBP")
 
@@ -34,7 +34,7 @@ class TestReconstruction:
         assert isinstance(stack, TomoStack)
         assert isinstance(rec, np.ndarray)
         data_shape = rec.data.shape
-        data_shape = cast(Tuple[int, int, int], data_shape)  # cast for type checking
+        data_shape = cast("tuple[int, int, int]", data_shape)  # cast for type checking
         assert data_shape[2] == slices.data.shape[1]
 
     def test_recon_unknown_algorithm(self):
@@ -135,7 +135,7 @@ class TestReconRun:
         slices = stack.isig[120:121, :].deepcopy()
         tilts = slices.tilts.data.squeeze()
         rec = recon.run(slices.data, tilts, "FBP", cuda=False)
-        data_shape = cast(Tuple[int, int, int], rec.data.shape)
+        data_shape = cast("tuple[int, int, int]", rec.data.shape)
         assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)
@@ -145,7 +145,7 @@ class TestReconRun:
         slices = stack.isig[120:121, :].deepcopy()
         tilts = slices.tilts.data.squeeze()
         rec = recon.run(slices.data.squeeze(), tilts, "FBP", cuda=False)
-        data_shape = cast(Tuple[int, int, int], rec.data.shape)
+        data_shape = cast("tuple[int, int, int]", rec.data.shape)
         assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)
@@ -155,7 +155,7 @@ class TestReconRun:
         slices = stack.isig[120:121, :].deepcopy()
         tilts = slices.tilts.data.squeeze()
         rec = recon.run(slices.data, tilts, "SIRT", niterations=2, cuda=False)
-        data_shape = cast(Tuple[int, int, int], rec.data.shape)
+        data_shape = cast("tuple[int, int, int]", rec.data.shape)
         assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)
@@ -165,7 +165,7 @@ class TestReconRun:
         slices = stack.isig[120:121, :].deepcopy()
         tilts = slices.tilts.data.squeeze()
         rec = recon.run(slices.data, tilts, "SART", niterations=2, cuda=False)
-        data_shape = cast(Tuple[int, int, int], rec.data.shape)
+        data_shape = cast("tuple[int, int, int]", rec.data.shape)
         assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)
@@ -184,7 +184,7 @@ class TestReconRun:
             gray_levels=gray_levels,
             dart_iterations=1,
         )
-        data_shape = cast(Tuple[int, int, int], rec.data.shape)
+        data_shape = cast("tuple[int, int, int]", rec.data.shape)
         assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)
@@ -234,10 +234,11 @@ class TestReconRun:
             dart_iterations=1,
             show_progressbar=False,
         )
-        data_shape = cast(Tuple[int, int, int], rec.data.shape)
+        data_shape = cast("tuple[int, int, int]", rec.data.shape)
         assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)
+
 
 class TestAstraError:
     """Test Astra toolbox errors."""
@@ -284,7 +285,7 @@ class TestAstraError:
             match=re.escape(
                 "Sinogram must be two-dimensional (ntilts, y). "
                 "Provided shape was (3, 5, 10).",
-                ),
+            ),
         ):
             recon.astra_error(
                 sino,
@@ -306,7 +307,7 @@ class TestAstraError:
                 "Number of angles must match size of the first dimension of the "
                 "sinogram. [len(angles) was 77; sinogram.shape was (3, 10)] "
                 "(77 != 3)",
-                ),
+            ),
         ):
             recon.astra_error(
                 sino,

--- a/etspy/utils.py
+++ b/etspy/utils.py
@@ -2,12 +2,11 @@
 
 import logging
 from multiprocessing import Pool
-from typing import Literal, Optional, cast
+from typing import TYPE_CHECKING, Literal, Optional, cast
 
 import numpy as np
 import tqdm
 from hyperspy._signals.signal2d import Signal2D
-from hyperspy.axes import UniformDataAxis as Uda
 from pystackreg import StackReg
 from scipy import ndimage
 
@@ -15,6 +14,9 @@ from etspy import _format_choices as _fmt
 from etspy import _get_literal_hint_values as _get_lit
 from etspy.align import calculate_shifts_stackreg
 from etspy.base import TomoStack
+
+if TYPE_CHECKING:
+    from hyperspy.axes import UniformDataAxis as Uda
 
 
 def multiaverage(stack: np.ndarray, nframes: int, ny: int, nx: int) -> np.ndarray:
@@ -106,9 +108,9 @@ def register_serialem_stack(stack: Signal2D, ncpus: int = 1) -> TomoStack:
         reg = np.array(reg)
 
     reg = TomoStack(reg)
-    reg_ax_0, reg_ax_1, reg_ax_2 = (cast(Uda, reg.axes_manager[i]) for i in range(3))
+    reg_ax_0, reg_ax_1, reg_ax_2 = (cast("Uda", reg.axes_manager[i]) for i in range(3))
     stack_ax_1, stack_ax_2, stack_ax_3 = (
-        cast(Uda, stack.axes_manager[i]) for i in range(1, 4)
+        cast("Uda", stack.axes_manager[i]) for i in range(1, 4)
     )
     reg_ax_0.scale = stack_ax_1.scale
     reg_ax_0.offset = stack_ax_1.offset
@@ -378,7 +380,7 @@ def get_radial_mask(
     utilities
     """
     if center is None:
-        center = cast(tuple[int, int], tuple(int(i / 2) for i in mask_shape))
+        center = cast("tuple[int, int]", tuple(int(i / 2) for i in mask_shape))
     radius = min(
         center[0],
         center[1],


### PR DESCRIPTION
`ruff` was throwing a bunch of errors which are now corrected.  The majority of them were related to two formatting issues:

* Quotes needed around `type` variable in `cast()` calls
* Deprecation of `Tuple` and `List` types in favor of built in `tuple` and `list`