### PR TITLE
Fixed dtype error in `base.trans_stack`

### DIFF
--- a/etspy/base.py
+++ b/etspy/base.py
@@ -497,6 +497,12 @@ class CommonStack(Signal2D, ABC):
             <TomoStack, title: , dimensions: (77|256, 256)>
         """
         transformed = self.deepcopy()
+        if interpolation.lower() in ["linear", "cubic"] and np.issubdtype(
+            transformed.data.dtype,
+            np.integer,
+        ):
+            transformed.data = transformed.data.astype("float32")
+            logger.debug("Data converted to float prior to transformation")
         theta = np.pi * angle / 180.0
         center_y, center_x = np.array(
             np.array(transformed.data.shape[1:]) / 2,


### PR DESCRIPTION
`skimage.transform.warp` returns all zeros when input images are of integer type and `cubic` interpolation is used.

Added a check for integer data and cubic interpolation. If True, data is converted to float prior to transformation.