### PR TITLE
Imporove pyproject.toml and enable uv compatibility

### DIFF
--- a/.github/actions/install-with-conda/action.yml
+++ b/.github/actions/install-with-conda/action.yml
@@ -5,13 +5,12 @@ inputs:
     default: etspy
     type: string
   python-version:
-    # default: "3.12"
     type: string
     required: true
   macos:
     default: false
     type: boolean
-    description: Whether to use MacOS conda environment (no cupy)
+    description: Whether to use MacOS conda environment which does not support CUDA
 
 runs:
   using: "composite"
@@ -28,9 +27,8 @@ runs:
       run: conda list
       shell: bash -el {0}
     - name: Install etspy development
-      # run: which pip && pip install -e ./
       # Only install CUDA related packages if not on MacOS
-      run:
+      run: |
         if [ "${{ inputs.macos }}" == "true" ]; then
           pip install --no-deps -e .
         else

--- a/.github/actions/install-with-conda/action.yml
+++ b/.github/actions/install-with-conda/action.yml
@@ -28,5 +28,12 @@ runs:
       run: conda list
       shell: bash -el {0}
     - name: Install etspy development
-      run: which pip && pip install -e ./
+      # run: which pip && pip install -e ./
+      # Only install CUDA related packages if not on MacOS
+      run:
+        if [ "${{ inputs.macos }}" == "true" ]; then
+          pip install --no-deps -e .
+        else
+          pip install --no-deps -e ".[gpu]"
+        fi
       shell: bash -el {0}

--- a/.github/actions/install-with-poetry/action.yml
+++ b/.github/actions/install-with-poetry/action.yml
@@ -2,7 +2,6 @@ name: Install ETSpy with poetry
 description: Uses poetry and CUDA action to install ETSpy and its dependencies
 inputs:
   python-version:
-    # default: "3.12"
     type: string
     required: true
   with-cuda:
@@ -30,5 +29,10 @@ runs:
         sub-packages: '["cudart"]'
         non-cuda-sub-packages: '["libcufft"]'
     - name: Install ETSpy using poetry
-      run: poetry install ${{ inputs.poetry-options }}
+      run: |
+        OPTIONS="${{ inputs.poetry-options }}"
+        if [ "${{ inputs.with-cuda }}" == "true" ]; then
+          OPTIONS="$OPTIONS --extras gpu"
+        fi
+        poetry install $OPTIONS
       shell: bash -el {0}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           with-cuda: false
           poetry-options: "--with=dev"
-          # python-version: "3.12"
+          python-version: "3.13"
       - name: Check links
         run: |
           cd ${{ env.DOC_SOURCE_PATH }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/actions/install-with-poetry
         with:
           with-cuda: false
-          poetry-options: "--with=dev --without=gpu"
+          poetry-options: "--with=dev"
           # python-version: "3.12"
       - name: Check links
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           with-cuda: true
-          poetry-options: "--with=dev --without=gpu"
+          poetry-options: "--with=dev"
       - name: Run docstring example tests
         run: poetry run pytest --doctest-modules --ignore=etspy/tests etspy/ 
       - name: Run full test suite

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           with-cuda: true
-          poetry-options: "--with=dev"
+          poetry-options: "--with=dev --extras gpu"
       - name: Run docstring example tests
         run: poetry run pytest --doctest-modules --ignore=etspy/tests etspy/ 
       - name: Run full test suite

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ hyperspy_log.py
 
 # poetry
 poetry.toml
+
+# uv
+uv.lock

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,8 +17,8 @@ If using conda, create and activate a new environment using one of the *developm
 
 | Description | Link |
 | ----------- | ---- |
-| Development environment without `cupy` | [`etspy-dev.yml`](https://raw.githubusercontent.com/usnistgov/etspy/refs/heads/master/resources/etspy-dev.yml) |
-| Development environment with `cupy` and CUDA packages for GPU operations | [`etspy-gpu-dev.yml`](https://raw.githubusercontent.com/usnistgov/etspy/refs/heads/master/resources/etspy-gpu-dev.yml) |
+| Development environment without `gpu` | [`etspy-dev.yml`](https://raw.githubusercontent.com/usnistgov/etspy/refs/heads/master/resources/etspy-dev.yml) |
+| Development environment with `gpu` and CUDA packages for GPU operations | [`etspy-gpu-dev.yml`](https://raw.githubusercontent.com/usnistgov/etspy/refs/heads/master/resources/etspy-gpu-dev.yml) |
 
 
 Then you will need to [fork the repository on Github](https://github.com/usnistgov/etspy/fork), clone the repo locally, and

--- a/etspy/__init__.py
+++ b/etspy/__init__.py
@@ -4,8 +4,9 @@ import importlib.metadata
 
 __version__ = importlib.metadata.version("etspy")
 
+from collections.abc import Callable
 from enum import Enum
-from typing import Callable, Literal, Union, get_args, get_type_hints
+from typing import Literal, get_args, get_type_hints
 
 
 class AlignmentMethod(str, Enum):
@@ -47,10 +48,7 @@ class AlignmentMethod(str, Enum):
         return [v.value for _, v in cls.__members__.items()]
 
 
-AlignmentMethodType = Union[
-    AlignmentMethod,
-    Literal["PC", "COM", "COM-CL", "StackReg"],
-]
+AlignmentMethodType = AlignmentMethod | Literal["PC", "COM", "COM-CL", "StackReg"]
 
 FbpMethodType = Literal[
     "ram-lak",

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -3,7 +3,7 @@
 # pyright: reportPossiblyUnboundVariable=false
 
 import logging
-from typing import TYPE_CHECKING, Literal, Optional, Union, cast
+from typing import TYPE_CHECKING, Literal, Union, cast
 
 import astra
 import matplotlib.pylab as plt
@@ -313,7 +313,7 @@ def pad_line(line: np.ndarray, paddedsize: int) -> np.ndarray:
 
 def calc_shifts_cl(
     stack: "TomoStack",
-    cl_ref_index: Optional[int],
+    cl_ref_index: int | None,
     cl_resolution: float,
     cl_div_factor: int,
 ) -> np.ndarray:
@@ -407,7 +407,7 @@ def calc_shifts_cl(
 
 def calculate_shifts_conservation_of_mass(
     stack: "TomoStack",
-    xrange: Optional[tuple[int, int]] = None,
+    xrange: tuple[int, int] | None = None,
     p: int = 20,
 ) -> np.ndarray:
     """
@@ -686,7 +686,7 @@ def calculate_shifts_pc(
 
 def calculate_shifts_stackreg(
     stack: "TomoStack",
-    start: Optional[int],
+    start: int | None,
     show_progressbar: bool,
 ) -> np.ndarray:
     """
@@ -743,7 +743,7 @@ def calculate_shifts_stackreg(
 def calc_shifts_com_cl(
     stack: "TomoStack",
     com_ref_index: int,
-    cl_ref_index: Optional[int] = None,
+    cl_ref_index: int | None = None,
     cl_resolution: float = 0.05,
     cl_div_factor: int = 8,
 ) -> np.ndarray:
@@ -810,16 +810,16 @@ def calc_shifts_com_cl(
 def align_stack(  # noqa: PLR0913
     stack: "TomoStack",
     method: AlignmentMethodType,
-    start: Optional[int],
+    start: int | None,
     show_progressbar: bool,
-    xrange: Optional[tuple[int, int]] = None,
+    xrange: tuple[int, int] | None = None,
     shift_type: Literal["fourier", "interp"] = "fourier",
     p: int = 20,
     nslices: int = 20,
     cuda: bool = False,
     upsample_factor: int = 3,
-    com_ref_index: Optional[int] = None,
-    cl_ref_index: Optional[int] = None,
+    com_ref_index: int | None = None,
+    cl_ref_index: int | None = None,
     cl_resolution: float = 0.05,
     cl_div_factor: int = 8,
 ) -> "TomoStack":
@@ -989,8 +989,8 @@ def align_stack(  # noqa: PLR0913
 
 def tilt_com(
     stack: "TomoStack",
-    slices: Optional[np.ndarray] = None,
-    nslices: Optional[int] = None,
+    slices: np.ndarray | None = None,
+    nslices: int | None = None,
 ) -> "TomoStack":
     """
     Perform tilt axis alignment using center of mass (CoM) tracking.

--- a/etspy/io.py
+++ b/etspy/io.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Optional, Union, cast
+from typing import Any, cast
 
 import numpy as np
 from hyperspy._signals.signal2d import (
@@ -20,7 +20,7 @@ from etspy.base import TomoStack
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-PathLike = Union[str, Path]
+PathLike = str | Path
 
 # declare known file types for later use
 hspy_file_types = [".hdf5", ".h5", ".hspy"]
@@ -30,9 +30,9 @@ known_file_types = hspy_file_types + mrc_file_types + dm_file_types
 
 
 def get_mrc_tilts(
-    stack: Union[Signal2D, TomoStack],
+    stack: Signal2D | TomoStack,
     filename: PathLike,
-) -> Optional[np.ndarray]:
+) -> np.ndarray | None:
     """Extract tilts from an MRC file.
 
     Parameters
@@ -78,7 +78,7 @@ def get_mrc_tilts(
     return tilts
 
 
-def get_dm_tilts(s: Union[Signal2D, TomoStack]) -> np.ndarray:
+def get_dm_tilts(s: Signal2D | TomoStack) -> np.ndarray:
     """Extract tilts from DM tags.
 
     Parameters
@@ -114,7 +114,7 @@ def get_dm_tilts(s: Union[Signal2D, TomoStack]) -> np.ndarray:
 def parse_mdoc(
     mdoc_file: PathLike,
     series: bool = False,
-) -> tuple[dict, Union[np.ndarray, float]]:
+) -> tuple[dict, np.ndarray | float]:
     """Parse experimental parameters from a SerialEM MDOC file.
 
     Parameters
@@ -223,8 +223,8 @@ def load_serialem(mrcfile: PathLike, mdocfile: PathLike) -> TomoStack:
 
 
 def load_serialem_series(
-    mrcfiles: Union[list[str], list[Path]],
-    mdocfiles: Union[list[str], list[Path]],
+    mrcfiles: list[str] | list[Path],
+    mdocfiles: list[str] | list[Path],
 ) -> tuple[Signal2D, np.ndarray]:
     """
     Load a multi-frame series collected by SerialEM.
@@ -424,9 +424,9 @@ def _load_single_file(filename: Path) -> TomoStack:
 
 
 def load(
-    filename: Union[PathLike, list[str], list[Path]],
-    tilts: Optional[Union[list[float], np.ndarray]] = None,
-    mdocs: Optional[Union[list[str], list[Path]]] = None,
+    filename: PathLike | list[str] | list[Path],
+    tilts: list[float] | np.ndarray | None = None,
+    mdocs: list[str] | list[Path] | None = None,
 ) -> TomoStack:
     """
     Create a TomoStack object using data from a file.

--- a/etspy/recon.py
+++ b/etspy/recon.py
@@ -584,7 +584,7 @@ def astra_error(
         if cuda:  # coverage: nocuda
             residual_error[i] = astra.algorithm.get_res_norm(alg)
         else:
-            curr_id, curr = astra.create_sino(rec[i], proj_id)
+            _, curr = astra.create_sino(rec[i], proj_id)
             residual_error[i] = np.linalg.norm(sinogram - curr)
     astra.clear()
 

--- a/etspy/simulation.py
+++ b/etspy/simulation.py
@@ -1,6 +1,6 @@
 """Simulation module for ETSpy package."""
 
-from typing import Literal, Optional, Union, cast
+from typing import Literal, cast
 
 import astra
 import hyperspy.api as hs
@@ -181,9 +181,9 @@ def create_cylinder_model(
 
 
 def create_model_tilt_series(
-    model: Union[np.ndarray, hs.signals.Signal2D],
-    angles: Optional[np.ndarray] = None,
-    cuda: Optional[bool] = None,
+    model: np.ndarray | hs.signals.Signal2D,
+    angles: np.ndarray | None = None,
+    cuda: bool | None = None,
 ) -> TomoStack:
     """
     Create a tilt series from a 3D volume.
@@ -242,7 +242,7 @@ def create_model_tilt_series(
         )  # coverage: nocuda
 
     for i in range(model.shape[0]):
-        sino_id, proj_data[:, :, i] = astra.create_sino(model[i, :, :], proj_id)
+        _, proj_data[:, :, i] = astra.create_sino(model[i, :, :], proj_id)
 
     stack = TomoStack(proj_data, angles)
     return stack

--- a/etspy/tests/test_align.py
+++ b/etspy/tests/test_align.py
@@ -95,7 +95,7 @@ class TestAlignFunctions:
         stack = ds.get_needle_data()
         with pytest.raises(
             ValueError,
-            match="nslices is greater than the X-dimension of the data.",
+            match=r"nslices is greater than the X-dimension of the data\.",
         ):
             etspy.align.tilt_com(stack, slices=None, nslices=300)
 
@@ -105,14 +105,14 @@ class TestAlignFunctions:
         with pytest.raises(
             ValueError,
             match=(
-                "Dataset is only 2 pixels in x dimension. This method cannot be used."
+                r"Dataset is only 2 pixels in x dimension. This method cannot be used."
             ),
         ):
             etspy.align.tilt_com(stack)
 
     def test_calc_shifts_com_cl_res_error(self):
         stack = ds.get_needle_data()
-        with pytest.raises(ValueError, match="Resolution should be less than 0.5"):
+        with pytest.raises(ValueError, match=(r"Resolution should be less than 0.5")):
             etspy.align.calc_shifts_com_cl(
                 stack,
                 com_ref_index=30,

--- a/etspy/tests/test_align.py
+++ b/etspy/tests/test_align.py
@@ -3,7 +3,6 @@
 import re
 import sys
 from importlib import reload
-from importlib.util import find_spec
 from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 
@@ -16,7 +15,15 @@ from etspy import datasets as ds
 if TYPE_CHECKING:
     from hyperspy.misc.utils import DictionaryTreeBrowser as Dtb
 
-cupy_in_test_env = find_spec("cupy") is not None
+
+# Check if CUDA capable GPU is available
+cupy_in_test_env = True
+try:
+    import cupy as cp
+
+    has_gpu = cp.cuda.runtime.getDeviceCount() > 0
+except Exception:
+    cupy_in_test_env = False
 
 
 class TestAlignFunctions:

--- a/etspy/tests/test_cuda.py
+++ b/etspy/tests/test_cuda.py
@@ -109,7 +109,7 @@ class TestAstraSIRTGPU:
 
     def test_astra_sirt_error_gpu_bad_dims(self):
         stack = ds.get_needle_data(aligned=True)
-        _, ny, _ = stack.data.shape
+        _, _, _ = stack.data.shape
         angles = stack.tilts.data.squeeze()
         stack = stack.isig[120:121, :]
         with pytest.raises(

--- a/etspy/tests/test_io.py
+++ b/etspy/tests/test_io.py
@@ -111,7 +111,7 @@ class TestLoadMRC:
         )
         with pytest.raises(
             ValueError,
-            match="Number of tilts in .rawtlt file inconsistent with data shape",
+            match=r"Number of tilts in .rawtlt file inconsistent with data shape",
         ):
             etspy.io.get_mrc_tilts(stack, filename)
 

--- a/etspy/tests/test_utils.py
+++ b/etspy/tests/test_utils.py
@@ -19,6 +19,7 @@ except TypeError:
 else:
     hspy_mrc_broken = False
 
+
 @pytest.mark.skipif(hspy_mrc_broken is True, reason="Hyperspy MRC reader broken")
 class TestMultiframeAverage:
     """Test taking a multiframe average of a stack."""
@@ -45,7 +46,7 @@ class TestMultiframeAverage:
         dirname = etspy_path / "tests" / "test_data" / "SerialEM_Multiframe_Test"
         files = dirname.glob("*.mrc")
         stack = io.load(list(files))
-        ntilts, nframes, ny, nx = stack.data.shape
+        _, nframes, ny, nx = stack.data.shape
         stack_avg = utils.multiaverage(stack.data[0], nframes, ny, nx)
         assert isinstance(stack_avg, np.ndarray)
         assert stack_avg.shape == (ny, nx)

--- a/etspy/tests/test_version.py
+++ b/etspy/tests/test_version.py
@@ -12,5 +12,5 @@ def test_version():
     pyproject = etspy_path.parent / "pyproject.toml"
     with pyproject.open("rb") as f:
         data = tomli.load(f)
-        toml_version = data["tool"]["poetry"]["version"]
+        toml_version = data["project"]["version"]
     assert importlib.metadata.version("etspy") == toml_version

--- a/etspy/utils.py
+++ b/etspy/utils.py
@@ -2,7 +2,7 @@
 
 import logging
 from multiprocessing import Pool
-from typing import TYPE_CHECKING, Literal, Optional, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 import numpy as np
 import tqdm
@@ -356,7 +356,7 @@ def calc_golden_ratio_angles(tilt_range: int, nangles: int) -> np.ndarray:
 
 def get_radial_mask(
     mask_shape: tuple[int, int],
-    center: Optional[tuple[int, int]] = None,
+    center: tuple[int, int] | None = None,
 ) -> np.ndarray:
     """
     Calculate a radial mask given a shape and center position.

--- a/poetry.lock
+++ b/poetry.lock
@@ -3785,30 +3785,31 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.6.9"
+version = "0.14.14"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.6.9-py3-none-linux_armv6l.whl", hash = "sha256:064df58d84ccc0ac0fcd63bc3090b251d90e2a372558c0f057c3f75ed73e1ccd"},
-    {file = "ruff-0.6.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:140d4b5c9f5fc7a7b074908a78ab8d384dd7f6510402267bc76c37195c02a7ec"},
-    {file = "ruff-0.6.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:53fd8ca5e82bdee8da7f506d7b03a261f24cd43d090ea9db9a1dc59d9313914c"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:645d7d8761f915e48a00d4ecc3686969761df69fb561dd914a773c1a8266e14e"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eae02b700763e3847595b9d2891488989cac00214da7f845f4bcf2989007d577"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d5ccc9e58112441de8ad4b29dcb7a86dc25c5f770e3c06a9d57e0e5eba48829"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:417b81aa1c9b60b2f8edc463c58363075412866ae4e2b9ab0f690dc1e87ac1b5"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c866b631f5fbce896a74a6e4383407ba7507b815ccc52bcedabb6810fdb3ef7"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b118afbb3202f5911486ad52da86d1d52305b59e7ef2031cea3425142b97d6f"},
-    {file = "ruff-0.6.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a67267654edc23c97335586774790cde402fb6bbdb3c2314f1fc087dee320bfa"},
-    {file = "ruff-0.6.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3ef0cc774b00fec123f635ce5c547dac263f6ee9fb9cc83437c5904183b55ceb"},
-    {file = "ruff-0.6.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:12edd2af0c60fa61ff31cefb90aef4288ac4d372b4962c2864aeea3a1a2460c0"},
-    {file = "ruff-0.6.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:55bb01caeaf3a60b2b2bba07308a02fca6ab56233302406ed5245180a05c5625"},
-    {file = "ruff-0.6.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:925d26471fa24b0ce5a6cdfab1bb526fb4159952385f386bdcc643813d472039"},
-    {file = "ruff-0.6.9-py3-none-win32.whl", hash = "sha256:eb61ec9bdb2506cffd492e05ac40e5bc6284873aceb605503d8494180d6fc84d"},
-    {file = "ruff-0.6.9-py3-none-win_amd64.whl", hash = "sha256:785d31851c1ae91f45b3d8fe23b8ae4b5170089021fbb42402d811135f0b7117"},
-    {file = "ruff-0.6.9-py3-none-win_arm64.whl", hash = "sha256:a9641e31476d601f83cd602608739a0840e348bda93fec9f1ee816f8b6798b93"},
-    {file = "ruff-0.6.9.tar.gz", hash = "sha256:b076ef717a8e5bc819514ee1d602bbdca5b4420ae13a9cf61a0c0a4f53a2baa2"},
+    {file = "ruff-0.14.14-py3-none-linux_armv6l.whl", hash = "sha256:7cfe36b56e8489dee8fbc777c61959f60ec0f1f11817e8f2415f429552846aed"},
+    {file = "ruff-0.14.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6006a0082336e7920b9573ef8a7f52eec837add1265cc74e04ea8a4368cd704c"},
+    {file = "ruff-0.14.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:026c1d25996818f0bf498636686199d9bd0d9d6341c9c2c3b62e2a0198b758de"},
+    {file = "ruff-0.14.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f666445819d31210b71e0a6d1c01e24447a20b85458eea25a25fe8142210ae0e"},
+    {file = "ruff-0.14.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c0f18b922c6d2ff9a5e6c3ee16259adc513ca775bcf82c67ebab7cbd9da5bc8"},
+    {file = "ruff-0.14.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1629e67489c2dea43e8658c3dba659edbfd87361624b4040d1df04c9740ae906"},
+    {file = "ruff-0.14.14-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:27493a2131ea0f899057d49d303e4292b2cae2bb57253c1ed1f256fbcd1da480"},
+    {file = "ruff-0.14.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:01ff589aab3f5b539e35db38425da31a57521efd1e4ad1ae08fc34dbe30bd7df"},
+    {file = "ruff-0.14.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc12d74eef0f29f51775f5b755913eb523546b88e2d733e1d701fe65144e89b"},
+    {file = "ruff-0.14.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb8481604b7a9e75eff53772496201690ce2687067e038b3cc31aaf16aa0b974"},
+    {file = "ruff-0.14.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:14649acb1cf7b5d2d283ebd2f58d56b75836ed8c6f329664fa91cdea19e76e66"},
+    {file = "ruff-0.14.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e8058d2145566510790eab4e2fad186002e288dec5e0d343a92fe7b0bc1b3e13"},
+    {file = "ruff-0.14.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e651e977a79e4c758eb807f0481d673a67ffe53cfa92209781dfa3a996cf8412"},
+    {file = "ruff-0.14.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:cc8b22da8d9d6fdd844a68ae937e2a0adf9b16514e9a97cc60355e2d4b219fc3"},
+    {file = "ruff-0.14.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:16bc890fb4cc9781bb05beb5ab4cd51be9e7cb376bf1dd3580512b24eb3fda2b"},
+    {file = "ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167"},
+    {file = "ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd"},
+    {file = "ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c"},
+    {file = "ruff-0.14.14.tar.gz", hash = "sha256:2d0f819c9a90205f3a867dbbd0be083bee9912e170fd7d9704cc8ae45824896b"},
 ]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -714,6 +714,39 @@ all = ["Cython (>=3)", "optuna (>=2.0)", "scipy (>=1.7,<1.17)"]
 test = ["hypothesis (>=6.37.2,<6.55.0)", "mpmath", "packaging", "pytest (>=7.2)"]
 
 [[package]]
+name = "cupy-cuda12x"
+version = "13.6.0"
+description = "CuPy: NumPy & SciPy for GPU"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "cupy_cuda12x-13.6.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:9e37f60f27ff9625dfdccc4688a09852707ec613e32ea9404f425dd22a386d14"},
+    {file = "cupy_cuda12x-13.6.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:e78409ea72f5ac7d6b6f3d33d99426a94005254fa57e10617f430f9fd7c3a0a1"},
+    {file = "cupy_cuda12x-13.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f33c9c975782ef7a42c79b6b4fb3d5b043498f9b947126d792592372b432d393"},
+    {file = "cupy_cuda12x-13.6.0-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:c790d012fd4d86872b9c89af9f5f15d91c30b8e3a4aa4dd04c2610f45f06ac44"},
+    {file = "cupy_cuda12x-13.6.0-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:77ba6745a130d880c962e687e4e146ebbb9014f290b0a80dbc4e4634eb5c3b48"},
+    {file = "cupy_cuda12x-13.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:a20b7acdc583643a623c8d8e3efbe0db616fbcf5916e9c99eedf73859b6133af"},
+    {file = "cupy_cuda12x-13.6.0-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:a6970ceefe40f9acbede41d7fe17416bd277b1bd2093adcde457b23b578c5a59"},
+    {file = "cupy_cuda12x-13.6.0-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:79b0cacb5e8b190ef409f9e03f06ac8de1b021b0c0dda47674d446f5557e0eb1"},
+    {file = "cupy_cuda12x-13.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:ca06fede7b8b83ca9ad80062544ef2e5bb8d4762d1c4fc3ac8349376de9c8a5e"},
+    {file = "cupy_cuda12x-13.6.0-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:e5426ae3b1b9cf59927481e457a89e3f0b50a35b114a8034ec9110e7a833434c"},
+    {file = "cupy_cuda12x-13.6.0-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:52d9e7f83d920da7d81ec2e791c2c2c747fdaa1d7b811971b34865ce6371e98a"},
+    {file = "cupy_cuda12x-13.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:297b4268f839de67ef7865c2202d3f5a0fb8d20bd43360bc51b6e60cb4406447"},
+    {file = "cupy_cuda12x-13.6.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:6ccd2fc75b0e0e24493531b8f8d8f978efecddb45f8479a48890c40d3805eb87"},
+    {file = "cupy_cuda12x-13.6.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:771f3135861b68199c18b49345210180d4fcdce4681b51c28224db389c4aac5d"},
+    {file = "cupy_cuda12x-13.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4d2dfd9bb4705d446f542739a3616b4c9eea98d674fce247402cc9bcec89a1e4"},
+]
+
+[package.dependencies]
+fastrlock = ">=0.5"
+numpy = ">=1.22,<2.6"
+
+[package.extras]
+all = ["Cython (>=3)", "optuna (>=2.0)", "scipy (>=1.7,<1.17)"]
+test = ["hypothesis (>=6.37.2,<6.55.0)", "mpmath", "packaging", "pytest (>=7.2)"]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 description = "Composable style cycles"
@@ -877,9 +910,9 @@ devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benc
 name = "fastrlock"
 version = "0.8.3"
 description = "Fast, re-entrant optimistic lock implemented in Cython"
-optional = true
+optional = false
 python-versions = "*"
-groups = ["gpu"]
+groups = ["main", "gpu"]
 files = [
     {file = "fastrlock-0.8.3-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bbbe31cb60ec32672969651bf68333680dacaebe1a1ec7952b8f5e6e23a70aa5"},
     {file = "fastrlock-0.8.3-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:45055702fe9bff719cdc62caa849aa7dbe9e3968306025f639ec62ef03c65e88"},
@@ -4724,11 +4757,11 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_it
 type = ["pytest-mypy"]
 
 [extras]
-all = ["ipykernel"]
-gpu = []
+all = ["cupy-cuda12x", "ipykernel"]
+gpu = ["cupy-cuda12x"]
 jupyter = ["ipykernel"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "00e90cdc8b436254b6f99ce199b6a2a8d9c56ba60d9fa94fc4f1428be49f0f64"
+content-hash = "1bc98fc67130c8db954d399ba422b0cde17bca16dc4924b2928b5a79ab037491"

--- a/poetry.lock
+++ b/poetry.lock
@@ -42,12 +42,12 @@ version = "0.1.4"
 description = "Disable App Nap on macOS >= 10.9"
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev", "jupyter"]
-markers = "platform_system == \"Darwin\""
+groups = ["main", "dev"]
 files = [
     {file = "appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c"},
     {file = "appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee"},
 ]
+markers = {main = "(extra == \"jupyter\" or extra == \"all\") and platform_system == \"Darwin\"", dev = "platform_system == \"Darwin\""}
 
 [[package]]
 name = "astra-toolbox"
@@ -76,7 +76,7 @@ version = "3.0.1"
 description = "Annotate AST trees with source code positions"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a"},
     {file = "asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7"},
@@ -131,8 +131,7 @@ version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "jupyter"]
-markers = "implementation_name == \"pypy\""
+groups = ["main", "dev"]
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -219,6 +218,7 @@ files = [
     {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
     {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
+markers = {main = "(extra == \"jupyter\" or extra == \"all\") and implementation_name == \"pypy\"", dev = "implementation_name == \"pypy\""}
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
@@ -379,12 +379,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
+markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\"", jupyter = "sys_platform == \"win32\""}
 
 [[package]]
 name = "comm"
@@ -392,7 +392,7 @@ version = "0.2.3"
 description = "Jupyter Python Comm implementation, for usage in ipykernel, xeus-python etc."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417"},
     {file = "comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971"},
@@ -695,31 +695,13 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
-name = "cupy"
+name = "cupy-cuda12x"
 version = "13.6.0"
 description = "CuPy: NumPy & SciPy for GPU"
 optional = true
 python-versions = ">=3.9"
-groups = ["gpu"]
-files = [
-    {file = "cupy-13.6.0.tar.gz", hash = "sha256:3cba30ae3dd32b5d5c6536e710cb98015227cd4ba83c46b3f1825a7ae55b6667"},
-]
-
-[package.dependencies]
-fastrlock = ">=0.5"
-numpy = ">=1.22,<2.6"
-
-[package.extras]
-all = ["Cython (>=3)", "optuna (>=2.0)", "scipy (>=1.7,<1.17)"]
-test = ["hypothesis (>=6.37.2,<6.55.0)", "mpmath", "packaging", "pytest (>=7.2)"]
-
-[[package]]
-name = "cupy-cuda12x"
-version = "13.6.0"
-description = "CuPy: NumPy & SciPy for GPU"
-optional = false
-python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"gpu\" or extra == \"all\""
 files = [
     {file = "cupy_cuda12x-13.6.0-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:9e37f60f27ff9625dfdccc4688a09852707ec613e32ea9404f425dd22a386d14"},
     {file = "cupy_cuda12x-13.6.0-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:e78409ea72f5ac7d6b6f3d33d99426a94005254fa57e10617f430f9fd7c3a0a1"},
@@ -799,7 +781,7 @@ version = "1.8.20"
 description = "An implementation of the Debug Adapter Protocol for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "debugpy-1.8.20-cp310-cp310-macosx_15_0_x86_64.whl", hash = "sha256:157e96ffb7f80b3ad36d808646198c90acb46fdcfd8bb1999838f0b6f2b59c64"},
     {file = "debugpy-1.8.20-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:c1178ae571aff42e61801a38b007af504ec8e05fde1c5c12e5a7efef21009642"},
@@ -832,6 +814,7 @@ files = [
     {file = "debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7"},
     {file = "debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33"},
 ]
+markers = {main = "extra == \"jupyter\" or extra == \"all\""}
 
 [[package]]
 name = "decorator"
@@ -839,7 +822,7 @@ version = "5.2.1"
 description = "Decorators for Humans"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a"},
     {file = "decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360"},
@@ -863,7 +846,7 @@ version = "1.3.1"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"},
@@ -882,7 +865,7 @@ version = "2.2.1"
 description = "Get the currently executing AST node of a frame, and other information"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017"},
     {file = "executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4"},
@@ -910,9 +893,10 @@ devel = ["colorama", "json-spec", "jsonschema", "pylint", "pytest", "pytest-benc
 name = "fastrlock"
 version = "0.8.3"
 description = "Fast, re-entrant optimistic lock implemented in Cython"
-optional = false
+optional = true
 python-versions = "*"
-groups = ["main", "gpu"]
+groups = ["main"]
+markers = "extra == \"gpu\" or extra == \"all\""
 files = [
     {file = "fastrlock-0.8.3-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bbbe31cb60ec32672969651bf68333680dacaebe1a1ec7952b8f5e6e23a70aa5"},
     {file = "fastrlock-0.8.3-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:45055702fe9bff719cdc62caa849aa7dbe9e3968306025f639ec62ef03c65e88"},
@@ -1426,11 +1410,12 @@ version = "6.31.0"
 description = "IPython Kernel for Jupyter"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "ipykernel-6.31.0-py3-none-any.whl", hash = "sha256:abe5386f6ced727a70e0eb0cf1da801fa7c5fa6ff82147747d5a0406cd8c94af"},
     {file = "ipykernel-6.31.0.tar.gz", hash = "sha256:2372ce8bc1ff4f34e58cafed3a0feb2194b91fc7cad0fc72e79e47b45ee9e8f6"},
 ]
+markers = {main = "extra == \"jupyter\" or extra == \"all\""}
 
 [package.dependencies]
 appnope = {version = ">=0.1.2", markers = "platform_system == \"Darwin\""}
@@ -1484,7 +1469,7 @@ version = "8.38.0"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "ipython-8.38.0-py3-none-any.whl", hash = "sha256:750162629d800ac65bb3b543a14e7a74b0e88063eac9b92124d4b2aa3f6d8e86"},
@@ -1524,7 +1509,7 @@ version = "9.10.0"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.11"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 markers = "python_version >= \"3.11\""
 files = [
     {file = "ipython-9.10.0-py3-none-any.whl", hash = "sha256:c6ab68cc23bba8c7e18e9b932797014cc61ea7fd6f19de180ab9ba73e65ee58d"},
@@ -1558,7 +1543,7 @@ version = "1.1.1"
 description = "Defines a variety of Pygments lexers for highlighting IPython code."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 markers = "python_version >= \"3.11\""
 files = [
     {file = "ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c"},
@@ -1611,7 +1596,7 @@ version = "0.19.2"
 description = "An autocompletion tool for Python that can be used for text editors."
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9"},
     {file = "jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0"},
@@ -1714,11 +1699,12 @@ version = "8.8.0"
 description = "Jupyter protocol implementation and client libraries"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "jupyter_client-8.8.0-py3-none-any.whl", hash = "sha256:f93a5b99c5e23a507b773d3a1136bd6e16c67883ccdbd9a829b0bbdb98cd7d7a"},
     {file = "jupyter_client-8.8.0.tar.gz", hash = "sha256:d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e"},
 ]
+markers = {main = "extra == \"jupyter\" or extra == \"all\""}
 
 [package.dependencies]
 jupyter-core = ">=5.1"
@@ -1738,11 +1724,12 @@ version = "5.9.1"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407"},
     {file = "jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508"},
 ]
+markers = {main = "extra == \"jupyter\" or extra == \"all\""}
 
 [package.dependencies]
 platformdirs = ">=2.5"
@@ -2133,7 +2120,7 @@ version = "0.2.1"
 description = "Inline Matplotlib backend for Jupyter"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76"},
     {file = "matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe"},
@@ -2318,11 +2305,12 @@ version = "1.6.0"
 description = "Patch asyncio to allow nested event loops"
 optional = false
 python-versions = ">=3.5"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c"},
     {file = "nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe"},
 ]
+markers = {main = "extra == \"jupyter\" or extra == \"all\""}
 
 [[package]]
 name = "networkx"
@@ -2375,7 +2363,7 @@ version = "2.2.6"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "gpu"]
+groups = ["main"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb"},
@@ -2441,7 +2429,7 @@ version = "2.4.2"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["main", "gpu"]
+groups = ["main"]
 markers = "python_version >= \"3.11\""
 files = [
     {file = "numpy-2.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7e88598032542bd49af7c4747541422884219056c268823ef6e5e89851c8825"},
@@ -2582,7 +2570,7 @@ version = "26.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
     {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
@@ -2594,7 +2582,7 @@ version = "0.8.6"
 description = "A Python Parser"
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff"},
     {file = "parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd"},
@@ -2629,7 +2617,7 @@ version = "4.9.0"
 description = "Pexpect allows easy control of interactive console applications."
 optional = false
 python-versions = "*"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523"},
@@ -2820,7 +2808,7 @@ version = "4.5.1"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31"},
     {file = "platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda"},
@@ -2871,7 +2859,7 @@ version = "3.0.52"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955"},
     {file = "prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855"},
@@ -2886,7 +2874,7 @@ version = "7.2.2"
 description = "Cross-platform lib for process and system monitoring."
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b"},
     {file = "psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea"},
@@ -2910,6 +2898,7 @@ files = [
     {file = "psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee"},
     {file = "psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372"},
 ]
+markers = {main = "extra == \"jupyter\" or extra == \"all\""}
 
 [package.extras]
 dev = ["abi3audit", "black", "check-manifest", "colorama ; os_name == \"nt\"", "coverage", "packaging", "psleak", "pylint", "pyperf", "pypinfo", "pyreadline3 ; os_name == \"nt\"", "pytest", "pytest-cov", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "validate-pyproject[all]", "virtualenv", "vulture", "wheel", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
@@ -2921,7 +2910,7 @@ version = "0.7.0"
 description = "Run a subprocess in a pseudo terminal"
 optional = false
 python-versions = "*"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 markers = "sys_platform != \"win32\" and sys_platform != \"emscripten\""
 files = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
@@ -2934,7 +2923,7 @@ version = "0.2.3"
 description = "Safely evaluate AST nodes without side effects"
 optional = false
 python-versions = "*"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0"},
     {file = "pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42"},
@@ -2949,12 +2938,12 @@ version = "3.0"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev", "jupyter"]
-markers = "implementation_name == \"pypy\""
+groups = ["main", "dev"]
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
+markers = {main = "(extra == \"jupyter\" or extra == \"all\") and implementation_name == \"pypy\"", dev = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "pydantic"
@@ -3161,7 +3150,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -3339,7 +3328,7 @@ version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
@@ -3437,7 +3426,7 @@ version = "27.1.0"
 description = "Python bindings for 0MQ"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "pyzmq-27.1.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:508e23ec9bc44c0005c4946ea013d9317ae00ac67778bd47519fdf5a0e930ff4"},
     {file = "pyzmq-27.1.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:507b6f430bdcf0ee48c0d30e734ea89ce5567fd7b8a0f0044a369c176aa44556"},
@@ -3532,6 +3521,7 @@ files = [
     {file = "pyzmq-27.1.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:ff8d114d14ac671d88c89b9224c63d6c4e5a613fe8acd5594ce53d752a3aafe9"},
     {file = "pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540"},
 ]
+markers = {main = "extra == \"jupyter\" or extra == \"all\""}
 
 [package.dependencies]
 cffi = {version = "*", markers = "implementation_name == \"pypy\""}
@@ -4094,7 +4084,7 @@ version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -4380,7 +4370,7 @@ version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
 optional = false
 python-versions = "*"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695"},
     {file = "stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9"},
@@ -4550,7 +4540,7 @@ version = "6.5.4"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "tornado-6.5.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d6241c1a16b1c9e4cc28148b1cda97dd1c6cb4fb7068ac1bedc610768dff0ba9"},
     {file = "tornado-6.5.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2d50f63dda1d2cac3ae1fa23d254e16b5e38153758470e9956cbc3d813d40843"},
@@ -4565,6 +4555,7 @@ files = [
     {file = "tornado-6.5.4-cp39-abi3-win_arm64.whl", hash = "sha256:053e6e16701eb6cbe641f308f4c1a9541f91b6261991160391bfc342e8a551a1"},
     {file = "tornado-6.5.4.tar.gz", hash = "sha256:a22fa9047405d03260b483980635f0b041989d8bcc9a313f8fe18b411d84b1d7"},
 ]
+markers = {main = "extra == \"jupyter\" or extra == \"all\""}
 
 [[package]]
 name = "tqdm"
@@ -4594,7 +4585,7 @@ version = "5.14.3"
 description = "Traitlets Python configuration system"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f"},
     {file = "traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7"},
@@ -4674,7 +4665,7 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
@@ -4719,7 +4710,7 @@ version = "0.6.0"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "jupyter"]
+groups = ["main", "dev"]
 files = [
     {file = "wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad"},
     {file = "wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159"},
@@ -4765,4 +4756,4 @@ jupyter = ["ipykernel"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "aac19443928cb6ff961985c89f3c3d2b83ddd9bcf73afa93dbe867d19fd0b152"
+content-hash = "12caa8aefaefce27a237430c5d93dcdc6171c36f3606b9e7b6520e76d287924f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4756,4 +4756,4 @@ jupyter = ["ipykernel"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "12caa8aefaefce27a237430c5d93dcdc6171c36f3606b9e7b6520e76d287924f"
+content-hash = "15c10a8f846c1884c5ace11341d5b5ce7d1a03382a75fddb23c2eb2de46dd8b2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4764,4 +4764,4 @@ jupyter = ["ipykernel"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "1bc98fc67130c8db954d399ba422b0cde17bca16dc4924b2928b5a79ab037491"
+content-hash = "aac19443928cb6ff961985c89f3c3d2b83ddd9bcf73afa93dbe867d19fd0b152"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "numpy>1.26",
     "scikit-image>=0.24,<0.26; python_version == '3.10'",
     "scikit-image>=0.26; python_version >= '3.11'",
-    "cupy-cuda12x>=13.6.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,20 +4,21 @@ version = "1.0.1"
 description = "Suite of tools for processing and reconstruction of electron tomography data"
 readme = "README.md"
 requires-python = ">=3.10"
+license = { text = "NIST Public License" }
 authors = [
     { name = "Andrew A. Herzing", email = "andrew.herzing@nist.gov" },
     { name = "Joshua Taillon", email = "joshua.taillon@nist.gov" }
 ]
 dependencies = [
-    "pystackreg>=0.2.8",
+    "pystackreg>=0.2.8,<0.3.0",
     "astra-toolbox>=2.1",
-    "hyperspy>=2.1.1",
-    "hyperspy-gui-ipywidgets>=2.0.2",
-    "typing-extensions>=4.12.2",
-    "h5py>=3.12.1",
+    "hyperspy>=2.1.1,<3.0.0",
+    "hyperspy-gui-ipywidgets>=2.0.2,<3.0.0",
+    "typing-extensions>=4.12.2,<5.0.0",
+    "h5py>=3.12.1,<4.0.0",
     "numpy>1.26",
     "scikit-image>=0.24,<0.26; python_version == '3.10'",
-    "scikit-image>=0.26; python_version >= '3.11'",
+    "scikit-image>=0.26,<1.0.0; python_version >= '3.11'",
 ]
 
 [project.optional-dependencies]
@@ -25,44 +26,18 @@ gpu = ["cupy-cuda12x>=13.3.0"]
 jupyter = ["ipykernel>=6.29.5"]
 all = ["cupy-cuda12x>=13.3.0", "ipykernel>=6.29.5"]
 
-[tool.poetry]
-name = "etspy"
-version = "1.0.1"
-description = "Suite of tools for processing and reconstruction of electron tomography data"
-authors = [
-    "Andrew A. Herzing <andrew.herzing@nist.gov>",
-    "Joshua Taillon <joshua.taillon@nist.gov>"
-]
-license = "NIST Public License"
-readme = "README.md"
+[project.urls]
 homepage = "https://pages.nist.gov/etspy/"
 repository = "https://github.com/usnistgov/etspy/"
 documentation = "https://pages.nist.gov/etspy/"
-packages = [
-    { include = "etspy" }
-]
 
-[tool.poetry.dependencies]
-python = ">=3.10"
-pystackreg = "^0.2.8"
-astra-toolbox = ">=2.1"
-hyperspy = "^2.1.1"
-hyperspy-gui-ipywidgets = "^2.0.2"
-typing-extensions = "^4.12.2"
-h5py = "^3.12.1"
-scikit-image = [
-    { version = ">=0.24,<0.26", python = "3.10" },
-    { version = "^0.26", python = ">=3.11" }
-]
-
-# extra optional dependencies for the "extras" groups (for "pip install etspy[...]")
-ipykernel = {version = "^6.29.5", optional = true}
-numpy = ">1.26"
+[tool.poetry]
+packages = [{ include = "etspy" }]
 
 [tool.poetry.group.dev.dependencies]
 pydocstyle = "^6.3.0"
 pytest = "^8.3.3"
-ruff = "<0.15.0"
+ruff = ">=0.9.0"
 isort = "^5.13.2"
 sphinx = "8.0.2"
 numpydoc = "^1.8.0"
@@ -72,25 +47,12 @@ myst-nb = "^1.1.2"
 pytest-cov = "^5.0.0"
 tomli = "^2.0.2"
 
-
-# [tool.poetry.group.gpu.dependencies]
-# cupy = {version = "^13.3.0", optional = true}
-
-
-# [tool.poetry.group.jupyter.dependencies]
-# ipykernel = "^6.29.5"
-
-[tool.poetry.extras]
-gpu = ["cupy"]
-jupyter = ["ipykernel"]
-all = ["cupy", "ipykernel"]  # shortcut for all extras
+[tool.poetry.plugins."hyperspy.extensions"]
+etspy = "etspy"
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.poetry.plugins."hyperspy.extensions"]
-etspy = "etspy"
 
 [tool.isort]
 profile = "black"
@@ -123,8 +85,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-# the parts of code covered by CUDA tests are excluded
-# by default
+# the parts of code covered by CUDA tests are excluded by default
 exclude_also = [
     "def _upsampled_dft",
     "def _cupy_phase_correlate",
@@ -137,7 +98,6 @@ testpaths = [
     "etspy/tests"
 ]
 addopts = "--cov=etspy --cov-report html:etspy/tests/htmlcov --cov-report=xml:etspy/tests/coverage.xml --cov-report term-missing --cov-append"
-#mpl-baseline-path = "etspy/tests/test_data/pytest_mpl_figures"
 
 [tool.mypy]
 disable_error_code = "import-untyped"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,13 @@ dependencies = [
     "numpy>1.26",
     "scikit-image>=0.24,<0.26; python_version == '3.10'",
     "scikit-image>=0.26; python_version >= '3.11'",
+    "cupy-cuda12x>=13.6.0",
 ]
 
 [project.optional-dependencies]
-gpu = ["cupy>=13.3.0"]
+gpu = ["cupy-cuda12x>=13.3.0"]
 jupyter = ["ipykernel>=6.29.5"]
-all = ["etspy[gpu,jupyter]"]
+all = ["cupy-cuda12x>=13.3.0", "ipykernel>=6.29.5"]
 
 [tool.poetry]
 name = "etspy"
@@ -57,13 +58,12 @@ scikit-image = [
 
 # extra optional dependencies for the "extras" groups (for "pip install etspy[...]")
 ipykernel = {version = "^6.29.5", optional = true}
-# cupy = {version = "^13.3.0", optional = true}
 numpy = ">1.26"
 
 [tool.poetry.group.dev.dependencies]
 pydocstyle = "^6.3.0"
 pytest = "^8.3.3"
-ruff = "^0.6.6"
+ruff = "<0.15.0"
 isort = "^5.13.2"
 sphinx = "8.0.2"
 numpydoc = "^1.8.0"
@@ -150,7 +150,7 @@ exclude = [
 dev-dependencies = [
     "pydocstyle>=6.3.0",
     "pytest>=8.3.3",
-    "ruff>=0.6.6",
+    "ruff<0.15.0",
     "isort>=5.13.2",
     "sphinx>=8.0.2",
     "numpydoc>=1.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,30 @@
+[project]
+name = "etspy"
+version = "1.0.1"
+description = "Suite of tools for processing and reconstruction of electron tomography data"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [
+    { name = "Andrew A. Herzing", email = "andrew.herzing@nist.gov" },
+    { name = "Joshua Taillon", email = "joshua.taillon@nist.gov" }
+]
+dependencies = [
+    "pystackreg>=0.2.8",
+    "astra-toolbox>=2.1",
+    "hyperspy>=2.1.1",
+    "hyperspy-gui-ipywidgets>=2.0.2",
+    "typing-extensions>=4.12.2",
+    "h5py>=3.12.1",
+    "numpy>1.26",
+    "scikit-image>=0.24,<0.26; python_version == '3.10'",
+    "scikit-image>=0.26; python_version >= '3.11'",
+]
+
+[project.optional-dependencies]
+gpu = ["cupy>=13.3.0"]
+jupyter = ["ipykernel>=6.29.5"]
+all = ["etspy[gpu,jupyter]"]
+
 [tool.poetry]
 name = "etspy"
 version = "1.0.1"
@@ -117,4 +144,19 @@ addopts = "--cov=etspy --cov-report html:etspy/tests/htmlcov --cov-report=xml:et
 disable_error_code = "import-untyped"
 exclude = [
     '^docs/conf\.py$'
+]
+
+[tool.uv]
+dev-dependencies = [
+    "pydocstyle>=6.3.0",
+    "pytest>=8.3.3",
+    "ruff>=0.6.6",
+    "isort>=5.13.2",
+    "sphinx>=8.0.2",
+    "numpydoc>=1.8.0",
+    "myst-parser>=4.0.0",
+    "sphinx-immaterial>=0.12.2",
+    "myst-nb>=1.1.2",
+    "pytest-cov>=5.0.0",
+    "tomli>=2.0.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,12 +73,12 @@ pytest-cov = "^5.0.0"
 tomli = "^2.0.2"
 
 
-[tool.poetry.group.gpu.dependencies]
-cupy = {version = "^13.3.0", optional = true}
+# [tool.poetry.group.gpu.dependencies]
+# cupy = {version = "^13.3.0", optional = true}
 
 
-[tool.poetry.group.jupyter.dependencies]
-ipykernel = "^6.29.5"
+# [tool.poetry.group.jupyter.dependencies]
+# ipykernel = "^6.29.5"
 
 [tool.poetry.extras]
 gpu = ["cupy"]

--- a/resources/etspy-dev.yml
+++ b/resources/etspy-dev.yml
@@ -21,4 +21,4 @@ dependencies:
   - sphinx==8.0.2
   - sphinx-immaterial
   - tomli
-  - typing_extensions
+  - typing-extensions

--- a/resources/etspy-dev.yml
+++ b/resources/etspy-dev.yml
@@ -18,6 +18,7 @@ dependencies:
   - pytest
   - pytest-cov
   - ruff
+  - scikit-image
   - sphinx==8.0.2
   - sphinx-immaterial
   - tomli

--- a/resources/etspy-gpu-dev.yml
+++ b/resources/etspy-gpu-dev.yml
@@ -22,4 +22,4 @@ dependencies:
   - sphinx==8.0.2
   - sphinx-immaterial
   - tomli
-  - typing_extensions
+  - typing-extensions

--- a/resources/etspy-gpu-dev.yml
+++ b/resources/etspy-gpu-dev.yml
@@ -19,6 +19,7 @@ dependencies:
   - pytest
   - pytest-cov
   - ruff
+  - scikit-image
   - sphinx==8.0.2
   - sphinx-immaterial
   - tomli

--- a/resources/etspy-gpu.yml
+++ b/resources/etspy-gpu.yml
@@ -12,4 +12,5 @@ dependencies:
   - pystackreg
   - pip
   - numpy
+  - scikit-image
   - typing-extensions

--- a/resources/etspy-gpu.yml
+++ b/resources/etspy-gpu.yml
@@ -12,4 +12,4 @@ dependencies:
   - pystackreg
   - pip
   - numpy
-  - typing_extensions
+  - typing-extensions

--- a/resources/etspy.yml
+++ b/resources/etspy.yml
@@ -11,4 +11,4 @@ dependencies:
   - pystackreg
   - pip
   - numpy
-  - typing_extensions
+  - typing-extensions

--- a/resources/etspy.yml
+++ b/resources/etspy.yml
@@ -11,4 +11,5 @@ dependencies:
   - pystackreg
   - pip
   - numpy
+  - scikit-image
   - typing-extensions


### PR DESCRIPTION
### Description
This PR updates the project configuration to use the modern **PEP 621** standard for project metadata and enables compatibility with the uv package manager.  

### Key Changes

#### 1. Configuration & Metadata
* **PEP 621 Migration:** Migrated project metadata (`name`, `version`, `authors`, etc.) from the Poetry-specific `[tool.poetry]` section to the standardized `[project]` section.
* **Dependency Standardization:** Converted all dependency definitions to **PEP 508** strings. Replaced Poetry's caret (`^`) syntax with explicit version ranges (e.g., `>=2.1.1,<3.0.0`) for better compatibility with non-Poetry tools like `pip` and `conda`.

#### 2. Dependency Management
* **Optional GPU Support:** Moved `cupy-cuda12x` into a new `[project.optional-dependencies]` group called `gpu`. This prevents installation failures on systems without CUDA support (specifically **macOS**).
* **Scikit-image version control:**  Ensure the correct version is pulled based on the user's Python version (3.10 vs 3.11+).
* **Conda Synchronization:** Updated `resources/etspy-dev.yml` to include `scikit-image`, ensuring the Conda-based CI environment is complete and doesn't rely on `pip` to resolve core dependencies.

### Testing Conducted
- [x] **Linting:** Verified `ruff` and `isort` pass
- [x] **Poetry CI:** Verified that the GPU extra installs correctly on Linux and all tests are passing.
- [x] **macOS CI:** Verified that tests pass without trying to install CUDA-specific packages.
- [x] **CUDA Functionality:** Ensured all tests, including those related to CUDA functionality, pass on local Linux machine.
- [x] **Conda CI:** Verified that `scikit-image` is correctly resolved by the environment manager.