### PR TITLE
Redefined TomoShifts and TomoTilts in extension metadata

### DIFF
--- a/etspy/hyperspy_extension.yaml
+++ b/etspy/hyperspy_extension.yaml
@@ -17,3 +17,15 @@ signals:
         dtype: real
         lazy: False
         module: etspy.base
+    TomoShifts:
+        signal_type: "TomoShifts"
+        signal_dimension: 1
+        dtype: real
+        lazy: False
+        module: etspy.base
+    TomoTilts:
+        signal_type: "TomoTilts"
+        signal_dimension: 1
+        dtype: real
+        lazy: False
+        module: etspy.base


### PR DESCRIPTION
### Description

This PR addresses issue #29.  

`Hyperspy` was producing a warning when using `etspy` to read an `.hdf5` or `.hspy` file previously saved through `etspy`:

```
WARNING | Hyperspy | `signal_type='TomoShifts'` not understood. See `hs.print_known_signal_types()` for a list of installed signal types or https://github.com/hyperspy/hyperspy-extensions-list for the list of all hyperspy extensions providing signals. (hyperspy.io:744)
```

This was because TomoShifts and TomoTilts were not defined in the extension metdata.  


### Progress of the PR
- [ x ] Define `TomoTilts` and `TomoShifts`  in the `hyperspy_extension.yaml`
- [ x ] Check that the warning does not occur
- [ x ] Check that all tests are passing
- [ x ] Ready for review

### Minimal example of the bug fix
```python
import etspy.api as et
import numpy as np

stack = et.TomoStack(np.random.random([10,100,100]), tilts=np.arange(10))
stack.save("stack.hspy")

# This line should not produce a warning from Hyperspy
newstack = et.load("stack.hspy")
```