### PR TITLE
Fix/fix several typing issues

### DIFF
--- a/etspy/align.py
+++ b/etspy/align.py
@@ -167,10 +167,12 @@ def apply_shifts(
         shifted_fft = fft.fft2(shifted.data, axes=(1, 2))
         for i in range(shifted.data.shape[0]):
             shifted.data[i, :, :] = np.real(
-                fft.ifft2(
-                    ndimage.fourier_shift(
-                        shifted_fft[i],
-                        shift=[shifts[i, 0], shifts[i, 1]],
+                np.asarray(
+                    fft.ifft2(
+                        ndimage.fourier_shift(
+                            shifted_fft[i],
+                            shift=[shifts[i, 0], shifts[i, 1]],
+                        ),
                     ),
                 ),
             )
@@ -278,8 +280,8 @@ def apply_shifts_cuda(
         msg = f"Invalid shift application method {method}."
         raise ValueError(msg)
 
-    shifted.data = data.get()
-    shifted.shifts.data = shifted.shifts.data + shifts.get()
+    shifted.data = cp.asnumpy(data)
+    shifted.shifts.data = shifted.shifts.data + cp.asnumpy(shifts)
     return shifted
 
 

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -24,13 +24,11 @@ if TYPE_CHECKING:
 
     from etspy.base import TomoShifts, TomoStack  # pragma: no cover
 
+has_cupy = True
 try:
     import cupy as cp  # type: ignore
     from cupyx.scipy.ndimage import fourier_shift as fourier_shift_gpu
     from cupyx.scipy.ndimage import shift as shift_gpu
-
-    if cp.is_available():
-        has_cupy = True
 except ImportError:
     has_cupy = False
 

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -24,11 +24,13 @@ if TYPE_CHECKING:
 
     from etspy.base import TomoShifts, TomoStack  # pragma: no cover
 
-has_cupy = True
 try:
     import cupy as cp  # type: ignore
     from cupyx.scipy.ndimage import fourier_shift as fourier_shift_gpu
     from cupyx.scipy.ndimage import shift as shift_gpu
+
+    if cp.is_available():
+        has_cupy = True
 except ImportError:
     has_cupy = False
 

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -27,7 +27,7 @@ from hyperspy.signal import BaseSignal, SpecialSlicersSignal
 from matplotlib.figure import Figure
 from scipy import ndimage
 from skimage import transform
-from traits.api import Undefined
+from traits.api import Undefined  # type: ignore
 
 from etspy import AlignmentMethod, AlignmentMethodType, FbpMethodType, ReconMethodType
 from etspy import _format_choices as _fmt
@@ -2269,7 +2269,7 @@ class RecStack(CommonStack):
     def interactive_rotation(
         self,
         slices: list | np.ndarray | None = None,
-        order: int | None = 3,
+        order: int = 3,
         figsize: tuple | None = (10, 4),
     ):
         """

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -42,15 +42,12 @@ if TYPE_CHECKING:
     from hyperspy.axes import UniformDataAxis as Uda
     from hyperspy.misc.utils import DictionaryTreeBrowser as Dtb
 
+has_cupy = True
 try:
-    import cupy as cp
+    import cupy as cp  # type: ignore
     from cupyx.scipy.ndimage import affine_transform as affine_transform_gpu
-
-    if cp.is_available():
-        has_cupy = True
 except ImportError:
     has_cupy = False
-    cp = None
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -2334,10 +2331,10 @@ class RecStack(CommonStack):
                 cval=0.0,
                 order=3,
             )
-        elif has_cupy and cp is not None:
+        else:
             data_gpu = cp.asarray(self.data.astype(np.float32))
 
-            rotated_gpu = affine_transform_gpu(  # type: ignore[name-defined]
+            rotated_gpu = affine_transform_gpu(
                 data_gpu,
                 cp.asarray(rotation_matrix),
                 offset=cp.asarray(offset),

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -743,7 +743,7 @@ class TomoStack(CommonStack):
     def __init__(
         self,
         data: np.ndarray | Signal2D,
-        tilts: TomoTilts | None = None,
+        tilts: TomoTilts | np.ndarray | None = None,
         shifts: TomoShifts | np.ndarray | None = None,
         *args,
         **kwargs,

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -42,12 +42,15 @@ if TYPE_CHECKING:
     from hyperspy.axes import UniformDataAxis as Uda
     from hyperspy.misc.utils import DictionaryTreeBrowser as Dtb
 
-has_cupy = True
 try:
-    import cupy as cp  # type: ignore
+    import cupy as cp
     from cupyx.scipy.ndimage import affine_transform as affine_transform_gpu
+
+    if cp.is_available():
+        has_cupy = True
 except ImportError:
     has_cupy = False
+    cp = None
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -2331,10 +2334,10 @@ class RecStack(CommonStack):
                 cval=0.0,
                 order=3,
             )
-        else:
+        elif has_cupy and cp is not None:
             data_gpu = cp.asarray(self.data.astype(np.float32))
 
-            rotated_gpu = affine_transform_gpu(
+            rotated_gpu = affine_transform_gpu(  # type: ignore[name-defined]
                 data_gpu,
                 cp.asarray(rotation_matrix),
                 offset=cp.asarray(offset),

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -27,7 +27,7 @@ from hyperspy.signal import BaseSignal, SpecialSlicersSignal
 from matplotlib.figure import Figure
 from scipy import ndimage
 from skimage import transform
-from traits.api import Undefined
+from traits.api import Undefined  # type: ignore
 
 from etspy import AlignmentMethod, AlignmentMethodType, FbpMethodType, ReconMethodType
 from etspy import _format_choices as _fmt
@@ -46,8 +46,10 @@ has_cupy = True
 try:
     import cupy as cp  # type: ignore
     from cupyx.scipy.ndimage import affine_transform as affine_transform_gpu
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     has_cupy = False
+    cp = None
+    affine_transform_gpu = None
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -2269,7 +2271,7 @@ class RecStack(CommonStack):
     def interactive_rotation(
         self,
         slices: list | np.ndarray | None = None,
-        order: int | None = 3,
+        order: int = 3,
         figsize: tuple | None = (10, 4),
     ):
         """
@@ -2331,7 +2333,7 @@ class RecStack(CommonStack):
                 cval=0.0,
                 order=3,
             )
-        else:
+        elif has_cupy and cp is not None and affine_transform_gpu is not None:
             data_gpu = cp.asarray(self.data.astype(np.float32))
 
             rotated_gpu = affine_transform_gpu(
@@ -2344,6 +2346,9 @@ class RecStack(CommonStack):
             )
 
             rotated.data = cp.asnumpy(rotated_gpu)
+        else:
+            msg = "CUDA selected buy CuPy is unavailable."
+            raise ValueError(msg)
 
         rotated.rotation_angles = rotation_angles
         rotated.rotation_matrix = rotation_matrix

--- a/etspy/io.py
+++ b/etspy/io.py
@@ -2,7 +2,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 from hyperspy._signals.signal2d import (
@@ -17,6 +17,9 @@ from hyperspy.misc.utils import (
 )
 
 from etspy.base import TomoStack
+
+if TYPE_CHECKING:
+    from hyperspy.misc.utils import DictionaryTreeBrowser as Dtb
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -201,6 +204,7 @@ def load_serialem(mrcfile: PathLike, mdocfile: PathLike) -> TomoStack:
 
     meta, _ = parse_mdoc(mdocfile)
     stack = hs_load(mrcfile)
+    stack = cast("Signal2D", stack)
 
     stack.axes_manager[1].scale = stack.axes_manager[1].scale / 10
     stack.axes_manager[2].scale = stack.axes_manager[2].scale / 10
@@ -283,6 +287,7 @@ def load_serialem_series(
         else:
             mrc_filename = mdoc_filename.with_suffix(".mrc")
         frames = hs_load(mrc_filename)
+        frames = cast("Signal2D", frames)
         nav = frames.axes_manager.navigation_axes[0]
         del nav.scale
         nav.name = "Frames"
@@ -394,6 +399,7 @@ def _load_single_file(filename: Path) -> TomoStack:
     tilts, shifts = None, None
     if ext.lower() in hspy_file_types:
         stack = hs_load(filename, reader="HSPY")
+        stack = cast("Signal2D", stack)
         if stack.metadata.has_item("Tomography.tilts"):
             tilts = stack.metadata.Tomography.tilts
             del stack.metadata.Tomography.tilts
@@ -402,6 +408,7 @@ def _load_single_file(filename: Path) -> TomoStack:
             del stack.metadata.Tomography.shifts
     elif ext.lower() in dm_file_types:
         stack = hs_load(filename)
+        stack = cast("Signal2D", stack)
         stack.axes_manager.navigation_axes[0].name = "Projections"
         stack.axes_manager.navigation_axes[0].units = "degrees"
         stack.change_dtype(np.float32)
@@ -409,6 +416,7 @@ def _load_single_file(filename: Path) -> TomoStack:
     elif ext.lower() in mrc_file_types:
         try:
             stack = hs_load(filename, reader="mrc")
+            stack = cast("Signal2D", stack)
             # TODO(jat): does a single mrc file ever have multiple tilts,
             # or is it just multiframe?
             tilts = get_mrc_tilts(stack, filename)
@@ -469,12 +477,14 @@ def load(
         ext = first_filename.suffix
         if ext.lower() in dm_file_types:
             s = hs_load(filename)
+            s = cast("Signal2D", s)
             tilts = [i.metadata.Acquisition_instrument.TEM.Stage.tilt_alpha for i in s]
             sorted_order = np.argsort(tilts)
             tilts = np.sort(tilts)
             files_sorted = list(np.array(filename)[sorted_order])
             del s
             stack = hs_load(files_sorted, stack=True, new_axis_name="Projections")
+            stack = cast("Signal2D", stack)
             stack.axes_manager.navigation_axes[0].units = "degrees"
             stack.axes_manager.navigation_axes[0].scale = np.diff(tilts).mean()
             stack.axes_manager.navigation_axes[0].offset = tilts[0]

--- a/etspy/visualize.py
+++ b/etspy/visualize.py
@@ -22,8 +22,8 @@ class VolumeSlicer:
     def __init__(
         self,
         stack: "TomoStack",
-        vmin_std: float = 0.1,
-        vmax_std: float = 10,
+        vmin_std: float | np.ndarray = 0.1,
+        vmax_std: float | np.ndarray = 10.0,
         figsize: tuple = (10, 4),
     ):
         """Initialize the VolumeSlicer Class.
@@ -41,10 +41,10 @@ class VolumeSlicer:
         figsize : tuple
             Size of matplotlib figure to use
         """
-        if type(vmin_std) in [float, int]:
-            vmin_std = vmin_std * np.ones(3)
-        if type(vmax_std) in [float, int]:
-            vmax_std = vmax_std * np.ones(3)
+        if isinstance(vmin_std, (int, float)):
+            vmin_std = np.asarray([vmin_std] * 3)
+        if isinstance(vmax_std, (int, float)):
+            vmax_std = np.asarray([vmax_std] * 3)
 
         nx, nz, ny = stack.data.shape
         self.stackZY = stack.deepcopy()


### PR DESCRIPTION
Several typing errors were being detected by pylance and several fixes have been implemented.  These include:

- added boundaries for `cupy` in `base.py`
- added missing type hints for `Signal2D` in io.py
- added missing `np.ndarray` type declaration for `vmin_std` and `vmax_std` in `VolumeSlicer.__init__`
- added missing `np.ndarray` type declaration for `tilts` in `TomoStack.__init__`
- ensured return of `scipy.fft.ifft2` was `np.ndarray` because of experimental support for `jax` and `cupy` arrays in the `scipy.fft` module
- changed `array.get()` calls in to more explicity `cp.asnumpy(array)` in `align.apply_shifts_cuda`