### PR TITLE
Fix/resolve several ci warnings

### DIFF
--- a/.github/actions/install-with-conda/action.yml
+++ b/.github/actions/install-with-conda/action.yml
@@ -23,6 +23,8 @@ runs:
         auto-update-conda: true
         python-version: ${{ inputs.python-version }}
         auto-activate: false
+        conda-remove-defaults: true
+        channels: conda-forge
     - name: Conda list
       run: conda list
       shell: bash -el {0}

--- a/.github/actions/install-with-conda/action.yml
+++ b/.github/actions/install-with-conda/action.yml
@@ -22,7 +22,7 @@ runs:
         environment-file: resources/etspy-dev.yml
         auto-update-conda: true
         python-version: ${{ inputs.python-version }}
-        auto-activate-base: false
+        auto-activate: false
     - name: Conda list
       run: conda list
       shell: bash -el {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - name: Install uv
-          uses: astral-sh/setup-uv@v5
+          uses: ./.github/actions/install-with-uv
           with:
             python-version: ${{ matrix.python-version }}
             with-cuda: ${{ matrix.os == 'ubuntu-latest' }} # Only enable CUDA on Linux


### PR DESCRIPTION
### Description
This PR fixes some minor problems in the actions and workflow settings that were causing warnings during GitHub CI testing.

### Key Changes

* **install with uv:** set to use local install-with-uv action isntead of astral-sh/setup-uv@v5
* **install with conda:** updated some arguments in the action file that were causing deprecation warnings
* **install with conda:** removed default channel and explicitly set channel to conda-forge

### Testing Conducted
- [x] **Linting:** Verified `ruff` and `isort` pass
- [x] **format-checks:** ensured format-checks were passing 
- [x] **uv CI:** Verified that warnings did not occur during uv install CI testing
- [x] **conda CI:** Verified that warnings did not occur during conda install CI testing
- [x] **pytest:** Ensured all tests, including those related to CUDA functionality, pass on local Linux machine

