### PR TITLE
Refactor/convert alignment code to class based approach

### DIFF
--- a/etspy/align.py
+++ b/etspy/align.py
@@ -17,8 +17,6 @@ from skimage.filters import sobel
 from skimage.registration import phase_cross_correlation as pcc
 from skimage.transform import hough_line, hough_line_peaks
 
-from etspy import AlignmentMethodType
-
 if TYPE_CHECKING:
     from hyperspy.misc.utils import DictionaryTreeBrowser as Dtb
 
@@ -1010,123 +1008,6 @@ class CommonLineAligner(StackAligner):
         padded_line = np.zeros(paddedsize)
         padded_line[start_index:end_index] = line
         return padded_line
-
-
-def align_stack(
-    stack: "TomoStack",
-    method: AlignmentMethodType,
-    start: int | None,
-) -> "TomoStack":
-    """
-    Compute the shifts for spatial registration.
-
-    Shifts are determined by one of three methods:
-        1.) Phase correlation (PC) as implemented in scikit-image. Based on:
-            Manuel Guizar-Sicairos, Samuel T. Thurman, and James R. Fienup.
-            Efficient subpixel image registration algorithms, Optics Letters vol. 33
-            (2008) pp. 156-158.
-            https://doi.org/10.1364/OL.33.000156
-        2.) Center of mass (COM) tracking.  A Python implementation of
-            algorithms described in:
-            T. Sanders. Physically motivated global alignment method for electron
-            tomography, Advanced Structural and Chemical Imaging vol. 1 (2015) pp 1-11.
-            https://doi.org/10.1186/s40679-015-0005-7
-        3.) Rigid translation using PyStackReg for shift calculation.
-            PyStackReg is a Python port of the StackReg plugin for ImageJ
-            which uses a pyramidal approach to minimize the least-squares
-            difference in image intensity between a source and target image.
-            StackReg is described in:
-            P. Thevenaz, U.E. Ruttimann, M. Unser. A Pyramid Approach to
-            Subpixel Registration Based on Intensity, IEEE Transactions
-            on Image Processing vol. 7, no. 1, pp. 27-41, January 1998.
-            https://doi.org/10.1109/83.650848
-        4.) A combination of center of mass tracking for aligment of
-            projections perpendicular to the tilt axis and common line
-            alignment for parallel to the tilt axis. This is a Python
-            implementation of Matlab code described in:
-            M. C. Scott, et al. Electron tomography at 2.4-ångström resolution,
-            Nature 483, 444-447 (2012).
-            https://doi.org/10.1038/nature10934
-
-    Shifts are then applied and the aligned stack is returned.  The tilts are
-    stored in stack.metadata.Tomography.shifts for later use.
-
-    Parameters
-    ----------
-    stack
-        3-D numpy array containing the tilt series data
-    method
-        Method by which to calculate the alignments. Valid options
-        are controlled by the :py:class:`etspy.AlignmentMethod` enum.
-    start
-        Position in tilt series to use as starting point for the alignment.
-        If None, the central projection is used.
-    show_progressbar
-        Enable/disable progress bar
-    xrange
-        (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM`)
-        The range for performing alignment. See
-        :py:func:`~etspy.align.calculate_shifts_com` for more details.
-    shift_type
-        Image shifts can be applied using either interpolation via scipy.ndimage.shift
-        or via Fourier shift as implemented in scipy.ndimage.fourier_shift.  Must be
-        either 'interp' or 'fourier'.
-    p
-        (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM`)
-        Padding element. See :py:func:`~etspy.align.calculate_shifts_com` for more
-        details.
-    nslices
-        (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM`)
-        Number of slices to return. See
-        :py:func:`~etspy.align.calculate_shifts_com` for more details.
-    cuda
-        (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.PC`)
-        Enable/disable the use of GPU-accelerated processes using CUDA. See
-        :py:func:`~etspy.align.calculate_shifts_pc` for more details.
-    upsample_factor
-        (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.PC`)
-        Factor by which to resample the data. See
-        :py:func:`~etspy.align.calculate_shifts_pc` for more details.
-    com_ref_index
-        (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
-        Reference slice for center of mass alignment.  All other slices will be aligned
-        to this reference. See :py:func:`~etspy.align.calc_shifts_com_cl` for more
-        details.
-    cl_ref_index
-        (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
-        Reference slice for common line alignment.  All other slices
-        will be aligned to this reference. If not provided the projection
-        closest to the middle of the stack will be chosen. See
-        :py:func:`~etspy.align.calc_shifts_com_cl` for more details.
-    cl_resolution
-        (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
-        Resolution for subpixel common line alignment. Default is 0.05.
-        Should be less than 0.5. See :py:func:`~etspy.align.calc_shifts_com_cl` for
-        more details.
-    cl_div_factor
-        (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
-        Factor which determines the number of iterations of common line
-        alignment to perform.  Default is 8. See
-        :py:func:`~etspy.align.calc_shifts_com_cl` for more details.
-
-    Returns
-    -------
-    out : TomoStack
-        Spatially registered copy of the input stack
-
-    Group
-    -----
-    align
-    """
-    if start is None:
-        start = (
-            stack.data.shape[0] // 2
-        )  # Use the slice closest to the midpoint if start is not provided
-    start = cast("int", start)  # explicit type cast for type checking
-
-    msg = f"Invalid alignment method {method}"
-    raise ValueError(msg)
-    return
 
 
 def tilt_com(

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -226,27 +226,50 @@ def apply_shifts(
     return shifted
 
 
-class AlignmentStrategy(ABC):
+class StackAligner(ABC):
     """Abstract Base class for Alignment methods."""
 
     def __init__(
         self,
+        stack: "TomoStack",
+        start: int | None = None,
         use_cuda: bool | None = False,
         show_progressbar: bool = False,
     ):
         use_cuda = cast("bool", use_cuda)
+        self.stack = stack
+        self.shifts = np.zeros([stack.data.shape[0], 2])
+        if start is None:
+            start = stack.data.shape[0] // 2
+        start = cast("int", start)
+        self.start = start
         self.use_cuda = use_cuda
         self.show_progressbar = show_progressbar
 
+    def align(
+        self,
+        shift_method: Literal["interp", "fourier"] = "fourier",
+    ) -> "TomoStack":
+        """
+        Perform stack alignment.
+
+        Shifts are calculated using the provided strategy and then applied using the
+        specified shift method.
+        """
+        self.shifts = self.calculate_shifts()
+
+        # Pass the strategy's CUDA preference to the applicator
+        return apply_shifts(
+            self.stack,
+            self.shifts,
+            method=shift_method,
+            cuda=self.use_cuda,
+        )
+
     @abstractmethod
-    def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
+    def calculate_shifts(self) -> np.ndarray:
         """
         Calculate the alignment shifts using the selected strategy.
-
-        Parameters
-        ----------
-        stack : :py:class:`~TomoStack`
-            The TomoStack series to be analyzed.
 
         Returns
         -------
@@ -259,50 +282,7 @@ class AlignmentStrategy(ABC):
         """
 
 
-class StackAligner:
-    """
-    Handles the orchestration of alignment.
-
-    Attributes
-    ----------
-    stack : :py:class:`~TomoStack`
-        The TomoStack to be aligned.
-
-    shifts : :py:class:`~numpy.ndarray`
-        The X- and Y-shifts to be applied to each image. Initialized
-        to an array of zeros with shape (n_images, 2).
-    """
-
-    def __init__(
-        self,
-        stack: "TomoStack",
-    ):
-        self.stack = stack
-        self.shifts = np.zeros([stack.data.shape[0], 2])
-
-    def align(
-        self,
-        strategy: AlignmentStrategy,
-        shift_method: Literal["interp", "fourier"] = "fourier",
-    ) -> "TomoStack":
-        """
-        Perform stack alignment.
-
-        Shifts are calculated using the provided strategy and then applied using the
-        specified shift method.
-        """
-        self.shifts = strategy.calculate_shifts(self.stack)
-
-        # Pass the strategy's CUDA preference to the applicator
-        return apply_shifts(
-            self.stack,
-            self.shifts,
-            method=shift_method,
-            cuda=strategy.use_cuda,
-        )
-
-
-class PhaseCorrelationAligner(AlignmentStrategy):
+class PhaseCorrelationAligner(StackAligner):
     """
     Aligner class for phase correlation (PC) strategy.
 
@@ -333,16 +313,21 @@ class PhaseCorrelationAligner(AlignmentStrategy):
 
     def __init__(
         self,
+        stack: "TomoStack",
         start: int = 0,
         upsample_factor: int = 3,
         use_cuda: bool = False,
         show_progressbar: bool = True,
     ):
-        super().__init__(use_cuda=use_cuda, show_progressbar=show_progressbar)
-        self.start = start
+        super().__init__(
+            stack=stack,
+            start=start,
+            use_cuda=use_cuda,
+            show_progressbar=show_progressbar,
+        )
         self.upsample_factor = upsample_factor
 
-    def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
+    def calculate_shifts(self) -> np.ndarray:
         """
         Calculate shifts using the phase correlation algorithm.
 
@@ -361,43 +346,43 @@ class PhaseCorrelationAligner(AlignmentStrategy):
         align
         """
         if has_cupy and astra.use_cuda() and self.use_cuda:
-            shifts = self._cupy_calculate_shifts(stack)
+            shifts = self._cupy_calculate_shifts()
 
         else:
-            shifts = np.zeros((stack.data.shape[0], 2))
+            shifts = np.zeros((self.stack.data.shape[0], 2))
             with tqdm.tqdm(
-                total=stack.data.shape[0] - 1,
+                total=self.stack.data.shape[0] - 1,
                 desc="Calculating shifts",
                 disable=not self.show_progressbar,
             ) as pbar:
                 for i in range(self.start, 0, -1):
                     shift = pcc(
-                        stack.data[i],
-                        stack.data[i - 1],
+                        self.stack.data[i],
+                        self.stack.data[i - 1],
                         upsample_factor=self.upsample_factor,
                     )[0]
                     shifts[i - 1] = shifts[i] + shift
                     pbar.update(1)
 
-                for i in range(self.start, stack.data.shape[0] - 1):
+                for i in range(self.start, self.stack.data.shape[0] - 1):
                     shift = pcc(
-                        stack.data[i],
-                        stack.data[i + 1],
+                        self.stack.data[i],
+                        self.stack.data[i + 1],
                         upsample_factor=self.upsample_factor,
                     )[0]
                     shifts[i + 1] = shifts[i] + shift
                     pbar.update(1)
         return shifts
 
-    def _cupy_calculate_shifts(self, stack):
+    def _cupy_calculate_shifts(self):
         """Calculate shifts of stack using CUDA-implementation of phase correlation."""
-        stack_cp = cp.array(stack.data)
+        stack_cp = cp.array(self.stack.data)
         shifts = cp.zeros([stack_cp.shape[0], 2])
         ref_cp = stack_cp[0]
         ref_fft = cp.fft.fftn(ref_cp)
         shape = ref_fft.shape
         with tqdm.tqdm(
-            total=stack.data.shape[0] - 1,
+            total=self.stack.data.shape[0] - 1,
             desc="Calculating shifts",
             disable=not self.show_progressbar,
         ) as pbar:
@@ -409,7 +394,7 @@ class PhaseCorrelationAligner(AlignmentStrategy):
                 )
                 shifts[i - 1] = shifts[i] + shift
                 pbar.update(1)
-            for i in range(self.start, stack.data.shape[0] - 1):
+            for i in range(self.start, self.stack.data.shape[0] - 1):
                 shift = self._cupy_phase_correlate(
                     stack_cp[i],
                     stack_cp[i + 1],
@@ -530,7 +515,7 @@ class PhaseCorrelationAligner(AlignmentStrategy):
         return data
 
 
-class StackRegAligner(AlignmentStrategy):
+class StackRegAligner(StackAligner):
     """
     Aligner class for StackReg strategy.
 
@@ -563,14 +548,18 @@ class StackRegAligner(AlignmentStrategy):
 
     def __init__(
         self,
+        stack: "TomoStack",
         start: int = 0,
         show_progressbar: bool = True,
     ):
-        super().__init__(use_cuda=False)
-        self.start = start
-        self.show_progressbar = show_progressbar
+        super().__init__(
+            stack=stack,
+            start=start,
+            use_cuda=False,
+            show_progressbar=show_progressbar,
+        )
 
-    def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
+    def calculate_shifts(self) -> np.ndarray:
         """
         Calculate shifts using PyStackReg.
 
@@ -585,11 +574,11 @@ class StackRegAligner(AlignmentStrategy):
             The shifts to be applied to each image
 
         """
-        shifts = np.zeros((stack.data.shape[0], 2))
+        shifts = np.zeros((self.stack.data.shape[0], 2))
 
         if self.start is None:
             self.start = (
-                stack.data.shape[0] // 2
+                self.stack.data.shape[0] // 2
             )  # Use the midpoint if start is not provided
         self.start = cast("int", self.start)
 
@@ -597,26 +586,32 @@ class StackRegAligner(AlignmentStrategy):
         reg = StackReg(StackReg.TRANSLATION)
 
         with tqdm.tqdm(
-            total=stack.data.shape[0] - 1,
+            total=self.stack.data.shape[0] - 1,
             desc="Calculating shifts",
             disable=not self.show_progressbar,
         ) as pbar:
             # Calculate shifts relative to the image at the 'start' index
             for i in range(self.start, 0, -1):
-                transformation = reg.register(stack.data[i], stack.data[i - 1])
+                transformation = reg.register(
+                    self.stack.data[i],
+                    self.stack.data[i - 1],
+                )
                 shift = -transformation[0:2, 2][::-1]
                 shifts[i - 1] = shifts[i] + shift
                 pbar.update(1)
 
-            for i in range(self.start, stack.data.shape[0] - 1):
-                transformation = reg.register(stack.data[i], stack.data[i + 1])
+            for i in range(self.start, self.stack.data.shape[0] - 1):
+                transformation = reg.register(
+                    self.stack.data[i],
+                    self.stack.data[i + 1],
+                )
                 shift = -transformation[0:2, 2][::-1]
                 shifts[i + 1] = shifts[i] + shift
                 pbar.update(1)
         return shifts
 
 
-class CoMAligner(AlignmentStrategy):
+class CoMAligner(StackAligner):
     """
     Center of mass (COM) tracking alignment strategy.
 
@@ -645,38 +640,37 @@ class CoMAligner(AlignmentStrategy):
 
     def __init__(
         self,
+        stack: "TomoStack",
         start: int = 0,
         show_progressbar: bool = True,
         xrange: tuple[int, int] | None = None,
         p: int = 20,
         nslices: int = 20,
     ):
-        super().__init__(use_cuda=False)
+        super().__init__(
+            stack=stack,
+            start=start,
+            use_cuda=False,
+            show_progressbar=show_progressbar,
+        )
         self.start = start
         self.show_progressbar = show_progressbar
         self.xrange = xrange
         self.p = p
         self.nslices = nslices
 
-    def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
+    def calculate_shifts(self) -> np.ndarray:
         """Calculate shifts using center of mass tracking method."""
         logger.info("Performing stack registration using center of mass method")
-        shifts = np.zeros([stack.data.shape[0], 2])
+        shifts = np.zeros([self.stack.data.shape[0], 2])
         # _calculate_shifts_conservation_of_mass: x-shifts (parallel to tilt axis)
         # _calculate_shifts_com: y-shifts (perpendicular to tilt axis)
-        shifts[:, 1] = self._calculate_shifts_conservation_of_mass(
-            stack,
-            self.xrange,
-            self.p,
-        )
-        shifts[:, 0] = self._calculate_shifts_com(stack)
+        shifts[:, 1] = self._calculate_shifts_conservation_of_mass()
+        shifts[:, 0] = self._calculate_shifts_com()
         return shifts
 
     def _calculate_shifts_conservation_of_mass(
         self,
-        stack: "TomoStack",
-        xrange: tuple[int, int] | None = None,
-        p: int = 20,
     ) -> np.ndarray:
         """
         Calculate shifts parallel to the tilt axis using conservation of mass.
@@ -703,36 +697,37 @@ class CoMAligner(AlignmentStrategy):
         align
         """
         logger.info("Refinining X-shifts using conservation of mass method")
-        ntilts, _, nx = stack.data.shape
+        ntilts, _, nx = self.stack.data.shape
 
-        if xrange is None:
+        if self.xrange is None:
             xrange = (round(nx / 5), round(4 / 5 * nx))
         else:
-            xrange = (round(xrange[0]) + p, round(xrange[1]) - p)
+            xrange = (round(self.xrange[0]) + self.p, round(self.xrange[1]) - self.p)
 
         xshifts = np.zeros([ntilts, 1])
-        total_mass = np.zeros([ntilts, xrange[1] - xrange[0] + 2 * p + 1])
+        total_mass = np.zeros([ntilts, xrange[1] - xrange[0] + 2 * self.p + 1])
 
         for i in range(ntilts):
             total_mass[i, :] = np.sum(
-                stack.data[i, :, xrange[0] - p - 1 : xrange[1] + p],
+                self.stack.data[i, :, xrange[0] - self.p - 1 : xrange[1] + self.p],
                 0,
             )
 
-        mean_mass = np.mean(total_mass[:, p:-p], 0)
+        mean_mass = np.mean(total_mass[:, self.p : -self.p], 0)
 
         for i in range(ntilts):
             s = 0
-            for j in range(-p, p):
-                resid = np.linalg.norm(mean_mass - total_mass[i, p + j : -p + j])
-                if resid < s or j == -p:
+            for j in range(-self.p, self.p):
+                resid = np.linalg.norm(
+                    mean_mass - total_mass[i, self.p + j : -self.p + j],
+                )
+                if resid < s or j == -self.p:
                     s = resid
                     xshifts[i] = -j
         return xshifts[:, 0]
 
     def _calculate_shifts_com(
         self,
-        stack: "TomoStack",
     ) -> np.ndarray:
         """
         Align stack using a center of mass method.
@@ -759,13 +754,13 @@ class CoMAligner(AlignmentStrategy):
         align
         """
         logger.info("Refinining Y-shifts using center of mass method")
-        slices = get_best_slices(stack, self.nslices)
+        slices = get_best_slices(self.stack, self.nslices)
 
-        angles = stack.tilts.data.squeeze()
-        ntilts, _, _ = stack.data.shape
+        angles = self.stack.tilts.data.squeeze()
+        ntilts, _, _ = self.stack.data.shape
         thetas = np.pi * cast("np.ndarray", angles) / 180
 
-        coms = get_coms(stack, slices)
+        coms = get_coms(self.stack, slices)
         i_tilts = np.eye(ntilts)
         gam = np.array([np.cos(thetas), np.sin(thetas)]).T
         gam = np.dot(gam, np.linalg.pinv(gam)) - i_tilts
@@ -777,7 +772,7 @@ class CoMAligner(AlignmentStrategy):
         return yshifts
 
 
-class CommonLineAligner(AlignmentStrategy):
+class CommonLineAligner(StackAligner):
     """
     Aligner class for common line (CL) strategy.
 
@@ -810,6 +805,7 @@ class CommonLineAligner(AlignmentStrategy):
 
     def __init__(
         self,
+        stack: "TomoStack",
         start: int = 0,
         show_progressbar: bool = True,
         com_ref_index: int | None = None,
@@ -817,44 +813,38 @@ class CommonLineAligner(AlignmentStrategy):
         cl_resolution: float = 0.05,
         cl_div_factor: int = 8,
     ):
-        super().__init__(use_cuda=False, show_progressbar=show_progressbar)
-        self.start = start
+        super().__init__(
+            stack=stack,
+            start=start,
+            use_cuda=False,
+            show_progressbar=show_progressbar,
+        )
         self.com_ref_index = com_ref_index
         self.cl_ref_index = cl_ref_index
         self.cl_resolution = cl_resolution
         self.cl_div_factor = cl_div_factor
 
-    def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
+    def calculate_shifts(self) -> np.ndarray:
         """Calculate shifts using combined center of mass and common line methods."""
         logger.info(
             "Performing stack registration using combined "
             "center of mass and common line methods",
         )
         if self.com_ref_index is None:
-            self.com_ref_index = stack.data.shape[1] // 2
+            self.com_ref_index = self.start
         if self.cl_ref_index is None:
-            self.cl_ref_index = stack.data.shape[0] // 2
+            self.cl_ref_index = self.start
 
         # explicit type casts for type checking
         self.com_ref_index = cast("int", self.com_ref_index)
         self.cl_ref_index = cast("int", self.cl_ref_index)
 
-        shifts = self._calc_shifts_com_cl(
-            stack,
-        )
+        shifts = self._calc_shifts_com_cl()
         return shifts
 
-    def _calc_shifts_com_cl(
-        self,
-        stack: "TomoStack",
-    ) -> np.ndarray:
+    def _calc_shifts_com_cl(self) -> np.ndarray:
         """
         Calculate shifts using combined center of mass and common line methods.
-
-        Parameters
-        ----------
-        stack : :py:class:`~TomoStack`
-            Tilt series to be aligned
 
         Returns
         -------
@@ -871,11 +861,10 @@ class CommonLineAligner(AlignmentStrategy):
 
         logger.info("Center of mass reference slice: %s", self.com_ref_index)
         logger.info("Common line reference slice: %s", self.cl_ref_index)
-        xshifts = np.zeros(stack.data.shape[0])
-        yshifts = np.zeros(stack.data.shape[0])
-        yshifts = self._calc_yshifts(stack, self.com_ref_index)
+        xshifts = np.zeros(self.stack.data.shape[0])
+        yshifts = np.zeros(self.stack.data.shape[0])
+        yshifts = self._calc_yshifts(self.com_ref_index)
         xshifts = self._calc_shifts_cl(
-            stack,
             self.cl_ref_index,
             self.cl_resolution,
             self.cl_div_factor,
@@ -883,21 +872,19 @@ class CommonLineAligner(AlignmentStrategy):
         shifts = np.stack([yshifts, xshifts], axis=1)
         return shifts
 
-    def _calc_yshifts(self, stack, com_ref):
-        ntilts = stack.data.shape[0]
-        ali_x = stack.deepcopy()
+    def _calc_yshifts(self, com_ref):
+        ntilts = self.stack.data.shape[0]
         coms = np.zeros(ntilts)
         yshifts = np.zeros_like(coms)
 
         for i in tqdm.tqdm(range(ntilts)):
-            im = ali_x.data[i, :, :]
+            im = self.stack.data[i, :, :]
             coms[i], _ = ndimage.center_of_mass(im)
             yshifts[i] = com_ref - coms[i]
         return yshifts
 
     def _calc_shifts_cl(
         self,
-        stack: "TomoStack",
         cl_ref_index: int | None,
         cl_resolution: float,
         cl_div_factor: int,
@@ -981,15 +968,15 @@ class CommonLineAligner(AlignmentStrategy):
             return -shift
 
         if cl_ref_index is None:
-            cl_ref_index = stack.data.shape[0] // 2
+            cl_ref_index = self.stack.data.shape[0] // 2
 
-        yshifts = np.zeros(stack.data.shape[0])
-        ref_cm_line = stack.data[cl_ref_index].sum(0)
+        yshifts = np.zeros(self.stack.data.shape[0])
+        ref_cm_line = self.stack.data[cl_ref_index].sum(0)
 
-        for i in tqdm.tqdm(range(stack.data.shape[0])):
+        for i in tqdm.tqdm(range(self.stack.data.shape[0])):
             if i == cl_ref_index:
                 continue
-            curr_cm_line = stack.data[i].sum(0)
+            curr_cm_line = self.stack.data[i].sum(0)
             yshifts[i] = align_line(
                 ref_cm_line,
                 curr_cm_line,

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -42,6 +42,190 @@ logger.setLevel(logging.INFO)
 CL_RES_THRESHOLD = 0.5  # threshold for common line registration method
 
 
+def get_best_slices(stack: "TomoStack", nslices: int) -> np.ndarray:
+    """
+    Get best nslices for center of mass analysis.
+
+    Slices which have the highest ratio of total mass to mass variance
+    and their location are returned.
+
+    Parameters
+    ----------
+    stack
+        Tilt series from which to select the best slices
+    nslices
+        Number of slices to return
+
+    Returns
+    -------
+    :py:class:`~numpy.ndarray`
+        Location along the x-axis of the best slices
+
+    Group
+    -----
+    align
+    """
+    total_mass = stack.data.sum((0, 1))
+    mass_std = stack.data.sum(1).std(0)
+    mass_std[mass_std == 0] = 1e-5
+    mass_ratio = total_mass / mass_std
+    best_slice_locations = mass_ratio.argsort()[::-1][0:nslices]
+    return best_slice_locations
+
+
+def get_coms(stack: "TomoStack", slices: np.ndarray) -> np.ndarray:
+    """
+    Calculate the center of mass for indicated slices.
+
+    Parameters
+    ----------
+    stack
+        Tilt series from which to calculate the centers of mass.
+    slices
+        Location of slices to use for center of mass calculation.
+
+    Returns
+    -------
+    :py:class:`~numpy.ndarray`
+        Center of mass as a function of tilt for each slice [ntilts, nslices].
+
+    Group
+    -----
+    align
+    """
+    sinos = stack.data[:, :, slices]
+    com_range = int(sinos.shape[1] / 2)
+    y_coordinates = np.linspace(-com_range, com_range, sinos.shape[1], dtype="int")
+    total_mass = sinos.sum(1)
+    coms = np.sum(np.transpose(sinos, [0, 2, 1]) * y_coordinates, 2) / total_mass
+    return coms
+
+
+def apply_shifts(
+    stack: "TomoStack",
+    shifts: Union["TomoShifts", np.ndarray],
+    method: Literal["interp", "fourier"] = "fourier",
+    cuda: bool = False,
+    **kwargs,
+) -> "TomoStack":
+    """
+    Apply a series of shifts to a TomoStack.
+
+    Shifts are applied to the data using either interpolation or Fourier shift methods.
+    These operations are carried out using either CPU or GPU resources depending on the
+    value of `cuda`. If `cuda` is True, the shifts will be applied using
+    GPU-acceleration via CuPy. The shifts are stored in
+    ``shifted.metadata.Tomography.shifts``.
+
+    Parameters
+    ----------
+    stack : :py:class:`~TomoStack`
+        The image series to be aligned
+    shifts : Union[:py:class:`~TomoShifts`, :py:class:`~numpy.ndarray`]
+        The X- (tilt parallel) and Y-shifts (tilt perpendicular) to be applied to
+        each image. Should be of size
+        ``(*stack.axes_manager.navigation_shape[::-1], 2)``,
+        with Y-shifts in the ``shifts[:, 0]`` position and X-shifts in ``shifts[:, 1]``
+        position (if ``shifts`` is a :py:class:`~numpy.ndarray`).
+    method : :py:class:`~str`
+        Image shifts can be applied using either interpolation via scipy.ndimage.shift
+        or via Fourier shift as implemented in scipy.ndimage.fourier_shift.  Must be
+        either 'interp' or 'fourier'.
+    cuda : :py:class:`~bool`
+        Enable/disable the use of GPU-accelerated processes using CUDA. If True, shifts
+        will be applied using CuPy. If False, shifts will be applied using NumPy and
+        SciPy.
+
+    Returns
+    -------
+    shifted : TomoStack
+        Copy of input stack after shifts are applied
+
+    Group
+    -----
+    align
+    """
+    shifted = stack.deepcopy()
+    xp = cp if cuda else np
+    fft_module = cp.fft if cuda else fft
+
+    if isinstance(shifts, BaseSignal):
+        shifts = shifts.data
+    shifts = cast("np.ndarray", shifts)
+
+    if len(shifts) != stack.data.shape[0]:
+        msg = (
+            f"Number of shifts ({len(shifts)}) is not consistent "
+            f"with number of images in the stack ({stack.data.shape[0]})"
+        )
+        raise ValueError(msg)
+
+    shifts = xp.array(shifts)
+
+    data = xp.array(shifted.data)
+    if method.lower() == "interp":
+        order = kwargs.pop("order", 3)
+        shift_func = shift_gpu if cuda else ndimage.shift
+        for i in range(data.shape[0]):
+            data[i, :, :] = shift_func(
+                data[i, :, :],
+                shift=[shifts[i, 0], shifts[i, 1]],
+                order=order,
+            )
+    elif method.lower() == "fourier":
+        ntilts, ny, nx = data.shape
+        y_pad_min = np.abs(shifts[:, 0]).max() + ny
+        ny_pad = int(2 ** np.ceil(np.log2(y_pad_min)))
+        y_pad_width = [(ny_pad - ny) // 2, (ny_pad - ny + 1) // 2]
+
+        x_pad_min = np.abs(shifts[:, 1]).max() + nx
+        nx_pad = int(2 ** np.ceil(np.log2(x_pad_min)))
+        x_pad_width = [(nx_pad - nx) // 2, (nx_pad - nx + 1) // 2]
+
+        data = xp.pad(
+            data,
+            ((0, 0), y_pad_width, x_pad_width),
+            mode="constant",
+        )
+
+        _, ny, nx = data.shape
+        data_fft = fft_module.fft2(data, axes=(1, 2))
+        data_fft = cast("Any", data_fft)
+
+        # Create frequency grids
+        # v is vertical frequencies, u is horizontal
+        v = xp.fft.fftfreq(ny).reshape(1, ny, 1)
+        u = xp.fft.fftfreq(nx).reshape(1, 1, nx)
+
+        # Reshape shifts for broadcasting: (n_images, 1, 1)
+        sy = shifts[:, 0].reshape(ntilts, 1, 1)
+        sx = shifts[:, 1].reshape(ntilts, 1, 1)
+
+        # Compute the phase ramp
+        # The formula: exp(-2j * pi * (v * sy + u * sx))
+        phi = -2j * np.pi * (v * sy + u * sx)
+        kernel = xp.exp(phi)
+
+        # Apply shift and Inverse FFT
+        data = xp.fft.ifft2(data_fft * kernel, axes=(1, 2))
+        data = xp.real(data)
+        slices = [
+            slice(0, None),
+        ]
+        for i in [y_pad_width, x_pad_width]:
+            i[1] = None if i[1] == 0 else -i[1]
+            slices.append(slice(i[0], i[1]))
+        data = data[tuple(slices)]
+    else:
+        msg = f"Invalid shift application method {method}."
+        raise ValueError(msg)
+
+    shifted.data = cp.asnumpy(data) if cuda else data
+    shifts = cp.asnumpy(shifts) if cuda else shifts
+    shifted.shifts.data = shifted.shifts.data + shifts
+    return shifted
+
+
 class AlignmentStrategy(ABC):
     """Abstract Base class for Alignment methods."""
 
@@ -681,19 +865,6 @@ class CommonLineAligner(AlignmentStrategy):
         -----
         align
         """
-
-        def calc_yshifts(stack, com_ref):
-            ntilts = stack.data.shape[0]
-            ali_x = stack.deepcopy()
-            coms = np.zeros(ntilts)
-            yshifts = np.zeros_like(coms)
-
-            for i in tqdm.tqdm(range(ntilts)):
-                im = ali_x.data[i, :, :]
-                coms[i], _ = ndimage.center_of_mass(im)
-                yshifts[i] = com_ref - coms[i]
-            return yshifts
-
         if self.cl_resolution >= CL_RES_THRESHOLD:
             msg = f"Resolution should be less than {CL_RES_THRESHOLD}"
             raise ValueError(msg)
@@ -702,8 +873,8 @@ class CommonLineAligner(AlignmentStrategy):
         logger.info("Common line reference slice: %s", self.cl_ref_index)
         xshifts = np.zeros(stack.data.shape[0])
         yshifts = np.zeros(stack.data.shape[0])
-        yshifts = calc_yshifts(stack, self.com_ref_index)
-        xshifts = calc_shifts_cl(
+        yshifts = self._calc_yshifts(stack, self.com_ref_index)
+        xshifts = self._calc_shifts_cl(
             stack,
             self.cl_ref_index,
             self.cl_resolution,
@@ -712,369 +883,147 @@ class CommonLineAligner(AlignmentStrategy):
         shifts = np.stack([yshifts, xshifts], axis=1)
         return shifts
 
+    def _calc_yshifts(self, stack, com_ref):
+        ntilts = stack.data.shape[0]
+        ali_x = stack.deepcopy()
+        coms = np.zeros(ntilts)
+        yshifts = np.zeros_like(coms)
 
-def get_best_slices(stack: "TomoStack", nslices: int) -> np.ndarray:
-    """
-    Get best nslices for center of mass analysis.
+        for i in tqdm.tqdm(range(ntilts)):
+            im = ali_x.data[i, :, :]
+            coms[i], _ = ndimage.center_of_mass(im)
+            yshifts[i] = com_ref - coms[i]
+        return yshifts
 
-    Slices which have the highest ratio of total mass to mass variance
-    and their location are returned.
+    def _calc_shifts_cl(
+        self,
+        stack: "TomoStack",
+        cl_ref_index: int | None,
+        cl_resolution: float,
+        cl_div_factor: int,
+    ) -> np.ndarray:
+        """
+        Calculate shifts using the common line method.
 
-    Parameters
-    ----------
-    stack
-        Tilt series from which to select the best slices
-    nslices
-        Number of slices to return
+        Used to align stack in dimension parallel to the tilt axis
 
-    Returns
-    -------
-    :py:class:`~numpy.ndarray`
-        Location along the x-axis of the best slices
+        Parameters
+        ----------
+        stack
+            The stack on which to calculate shifts
+        cl_ref_index
+            Tilt index of reference projection. If not provided the projection
+            closest to the middle of the stack will be chosen.
+        cl_resolution
+            Degree of sub-pixel analysis
+        cl_div_factor
+            Factor used to determine number of iterations of alignment.
 
-    Group
-    -----
-    align
-    """
-    total_mass = stack.data.sum((0, 1))
-    mass_std = stack.data.sum(1).std(0)
-    mass_std[mass_std == 0] = 1e-5
-    mass_ratio = total_mass / mass_std
-    best_slice_locations = mass_ratio.argsort()[::-1][0:nslices]
-    return best_slice_locations
+        Returns
+        -------
+        yshifts : :py:class:`~numpy.ndarray`
+            Shifts parallel to tilt axis for each projection
 
+        Group
+        -----
+        align
+        """
 
-def get_coms(stack: "TomoStack", slices: np.ndarray) -> np.ndarray:
-    """
-    Calculate the center of mass for indicated slices.
+        def align_line(ref_line, line, cl_resolution, cl_div_factor):
+            npad = len(ref_line) * 2 - 1
 
-    Parameters
-    ----------
-    stack
-        Tilt series from which to calculate the centers of mass.
-    slices
-        Location of slices to use for center of mass calculation.
+            # Pad with zeros while preserving the center location
+            ref_line_pad = self._pad_line(ref_line, npad)
+            line_pad = self._pad_line(line, npad)
 
-    Returns
-    -------
-    :py:class:`~numpy.ndarray`
-        Center of mass as a function of tilt for each slice [ntilts, nslices].
-
-    Group
-    -----
-    align
-    """
-    sinos = stack.data[:, :, slices]
-    com_range = int(sinos.shape[1] / 2)
-    y_coordinates = np.linspace(-com_range, com_range, sinos.shape[1], dtype="int")
-    total_mass = sinos.sum(1)
-    coms = np.sum(np.transpose(sinos, [0, 2, 1]) * y_coordinates, 2) / total_mass
-    return coms
-
-
-def apply_shifts(
-    stack: "TomoStack",
-    shifts: Union["TomoShifts", np.ndarray],
-    method: Literal["interp", "fourier"] = "fourier",
-    cuda: bool = False,
-    **kwargs,
-) -> "TomoStack":
-    """
-    Apply a series of shifts to a TomoStack.
-
-    Shifts are applied to the data using either interpolation or Fourier shift methods.
-    These operations are carried out using either CPU or GPU resources depending on the
-    value of `cuda`. If `cuda` is True, the shifts will be applied using
-    GPU-acceleration via CuPy. The shifts are stored in
-    ``shifted.metadata.Tomography.shifts``.
-
-    Parameters
-    ----------
-    stack : :py:class:`~TomoStack`
-        The image series to be aligned
-    shifts : Union[:py:class:`~TomoShifts`, :py:class:`~numpy.ndarray`]
-        The X- (tilt parallel) and Y-shifts (tilt perpendicular) to be applied to
-        each image. Should be of size
-        ``(*stack.axes_manager.navigation_shape[::-1], 2)``,
-        with Y-shifts in the ``shifts[:, 0]`` position and X-shifts in ``shifts[:, 1]``
-        position (if ``shifts`` is a :py:class:`~numpy.ndarray`).
-    method : :py:class:`~str`
-        Image shifts can be applied using either interpolation via scipy.ndimage.shift
-        or via Fourier shift as implemented in scipy.ndimage.fourier_shift.  Must be
-        either 'interp' or 'fourier'.
-    cuda : :py:class:`~bool`
-        Enable/disable the use of GPU-accelerated processes using CUDA. If True, shifts
-        will be applied using CuPy. If False, shifts will be applied using NumPy and
-        SciPy.
-
-    Returns
-    -------
-    shifted : TomoStack
-        Copy of input stack after shifts are applied
-
-    Group
-    -----
-    align
-    """
-    shifted = stack.deepcopy()
-    xp = cp if cuda else np
-    fft_module = cp.fft if cuda else fft
-
-    if isinstance(shifts, BaseSignal):
-        shifts = shifts.data
-    shifts = cast("np.ndarray", shifts)
-
-    if len(shifts) != stack.data.shape[0]:
-        msg = (
-            f"Number of shifts ({len(shifts)}) is not consistent "
-            f"with number of images in the stack ({stack.data.shape[0]})"
-        )
-        raise ValueError(msg)
-
-    shifts = xp.array(shifts)
-
-    data = xp.array(shifted.data)
-    if method.lower() == "interp":
-        order = kwargs.pop("order", 3)
-        shift_func = shift_gpu if cuda else ndimage.shift
-        for i in range(data.shape[0]):
-            data[i, :, :] = shift_func(
-                data[i, :, :],
-                shift=[shifts[i, 0], shifts[i, 1]],
-                order=order,
+            niters = int(
+                np.abs(np.floor(np.log(cl_resolution) / np.log(cl_div_factor))),
             )
-    elif method.lower() == "fourier":
-        ntilts, ny, nx = data.shape
-        y_pad_min = np.abs(shifts[:, 0]).max() + ny
-        ny_pad = int(2 ** np.ceil(np.log2(y_pad_min)))
-        y_pad_width = [(ny_pad - ny) // 2, (ny_pad - ny + 1) // 2]
+            start, end = -0.5, 0.5
 
-        x_pad_min = np.abs(shifts[:, 1]).max() + nx
-        nx_pad = int(2 ** np.ceil(np.log2(x_pad_min)))
-        x_pad_width = [(nx_pad - nx) // 2, (nx_pad - nx + 1) // 2]
+            ref_line_pad_ft = np.fft.fftshift(
+                np.fft.fft(np.fft.ifftshift(ref_line_pad)),
+            )
+            line_pad_ft = np.fft.fftshift(np.fft.fft(np.fft.ifftshift(line_pad)))
 
-        data = xp.pad(
-            data,
-            ((0, 0), y_pad_width, x_pad_width),
-            mode="constant",
-        )
+            midpoint = (npad - 1) / 2
+            kx = np.arange(-midpoint, midpoint + 1)
 
-        _, ny, nx = data.shape
-        data_fft = fft_module.fft2(data, axes=(1, 2))
-        data_fft = cast("Any", data_fft)
+            for _ in range(niters):
+                boundary = np.linspace(start, end, cl_div_factor, endpoint=False)
+                index = (boundary[:-1] + boundary[1:]) / 2
 
-        # Create frequency grids
-        # v is vertical frequencies, u is horizontal
-        v = xp.fft.fftfreq(ny).reshape(1, ny, 1)
-        u = xp.fft.fftfreq(nx).reshape(1, 1, nx)
+                max_vals = np.zeros(len(index))
+                for j, idx in enumerate(index):
+                    pfactor = np.exp(2 * np.pi * 1j * (idx * kx / npad))
+                    conjugate = np.conj(ref_line_pad_ft) * line_pad_ft * pfactor
+                    xcorr = np.abs(
+                        np.fft.fftshift(np.fft.ifft(np.fft.ifftshift(conjugate))),
+                    )
+                    max_vals[j] = np.max(xcorr)
 
-        # Reshape shifts for broadcasting: (n_images, 1, 1)
-        sy = shifts[:, 0].reshape(ntilts, 1, 1)
-        sx = shifts[:, 1].reshape(ntilts, 1, 1)
+                max_loc = np.argmax(max_vals)
+                start, end = boundary[max_loc], boundary[max_loc + 1]
 
-        # Compute the phase ramp
-        # The formula: exp(-2j * pi * (v * sy + u * sx))
-        phi = -2j * np.pi * (v * sy + u * sx)
-        kernel = xp.exp(phi)
+            subpixel_shift = index[max_loc]
+            max_pfactor = np.exp(2 * np.pi * 1j * (subpixel_shift * kx / npad))
 
-        # Apply shift and Inverse FFT
-        data = xp.fft.ifft2(data_fft * kernel, axes=(1, 2))
-        data = xp.real(data)
-        slices = [
-            slice(0, None),
-        ]
-        for i in [y_pad_width, x_pad_width]:
-            i[1] = None if i[1] == 0 else -i[1]
-            slices.append(slice(i[0], i[1]))
-        data = data[tuple(slices)]
-    else:
-        msg = f"Invalid shift application method {method}."
-        raise ValueError(msg)
+            # Determine integer shift via cross correlation
+            conjugate = np.conj(ref_line_pad_ft) * line_pad_ft * max_pfactor
+            xcorr = np.abs(np.fft.fftshift(np.fft.ifft(np.fft.ifftshift(conjugate))))
+            max_loc = np.argmax(xcorr)
 
-    shifted.data = cp.asnumpy(data) if cuda else data
-    shifts = cp.asnumpy(shifts) if cuda else shifts
-    shifted.shifts.data = shifted.shifts.data + shifts
-    return shifted
+            integer_shift = max_loc
+            integer_shift = integer_shift - midpoint
 
+            # Calculate full shift
+            shift = integer_shift + subpixel_shift
+            return -shift
 
-def pad_line(line: np.ndarray, paddedsize: int) -> np.ndarray:
-    """
-    Pad a 1D array for FFT treatment without altering center location.
+        if cl_ref_index is None:
+            cl_ref_index = stack.data.shape[0] // 2
 
-    Parameters
-    ----------
-    line
-        The data to be padded (should be 1D)
-    paddedsize
-        The size of the desired padded data.
+        yshifts = np.zeros(stack.data.shape[0])
+        ref_cm_line = stack.data[cl_ref_index].sum(0)
 
-    Returns
-    -------
-    padded : :py:class:`~numpy.ndarray`
-        Padded version of input data (1 dimensional)
+        for i in tqdm.tqdm(range(stack.data.shape[0])):
+            if i == cl_ref_index:
+                continue
+            curr_cm_line = stack.data[i].sum(0)
+            yshifts[i] = align_line(
+                ref_cm_line,
+                curr_cm_line,
+                cl_resolution,
+                cl_div_factor,
+            )
+        return yshifts
 
-    Group
-    -----
-    align
-    """
-    npix = len(line)
-    start_index = (paddedsize - npix) // 2
-    end_index = start_index + npix
-    padded_line = np.zeros(paddedsize)
-    padded_line[start_index:end_index] = line
-    return padded_line
+    def _pad_line(self, line: np.ndarray, paddedsize: int) -> np.ndarray:
+        """
+        Pad a 1D array for FFT treatment without altering center location.
 
+        Parameters
+        ----------
+        line
+            The data to be padded (should be 1D)
+        paddedsize
+            The size of the desired padded data.
 
-def calc_shifts_cl(
-    stack: "TomoStack",
-    cl_ref_index: int | None,
-    cl_resolution: float,
-    cl_div_factor: int,
-) -> np.ndarray:
-    """
-    Calculate shifts using the common line method.
+        Returns
+        -------
+        padded : :py:class:`~numpy.ndarray`
+            Padded version of input data (1 dimensional)
 
-    Used to align stack in dimension parallel to the tilt axis
-
-    Parameters
-    ----------
-    stack
-        The stack on which to calculate shifts
-    cl_ref_index
-        Tilt index of reference projection. If not provided the projection
-        closest to the middle of the stack will be chosen.
-    cl_resolution
-        Degree of sub-pixel analysis
-    cl_div_factor
-        Factor used to determine number of iterations of alignment.
-
-    Returns
-    -------
-    yshifts : :py:class:`~numpy.ndarray`
-        Shifts parallel to tilt axis for each projection
-
-    Group
-    -----
-    align
-    """
-
-    def align_line(ref_line, line, cl_resolution, cl_div_factor):
-        npad = len(ref_line) * 2 - 1
-
-        # Pad with zeros while preserving the center location
-        ref_line_pad = pad_line(ref_line, npad)
-        line_pad = pad_line(line, npad)
-
-        niters = int(np.abs(np.floor(np.log(cl_resolution) / np.log(cl_div_factor))))
-        start, end = -0.5, 0.5
-
-        ref_line_pad_ft = np.fft.fftshift(np.fft.fft(np.fft.ifftshift(ref_line_pad)))
-        line_pad_ft = np.fft.fftshift(np.fft.fft(np.fft.ifftshift(line_pad)))
-
-        midpoint = (npad - 1) / 2
-        kx = np.arange(-midpoint, midpoint + 1)
-
-        for _ in range(niters):
-            boundary = np.linspace(start, end, cl_div_factor, endpoint=False)
-            index = (boundary[:-1] + boundary[1:]) / 2
-
-            max_vals = np.zeros(len(index))
-            for j, idx in enumerate(index):
-                pfactor = np.exp(2 * np.pi * 1j * (idx * kx / npad))
-                conjugate = np.conj(ref_line_pad_ft) * line_pad_ft * pfactor
-                xcorr = np.abs(
-                    np.fft.fftshift(np.fft.ifft(np.fft.ifftshift(conjugate))),
-                )
-                max_vals[j] = np.max(xcorr)
-
-            max_loc = np.argmax(max_vals)
-            start, end = boundary[max_loc], boundary[max_loc + 1]
-
-        subpixel_shift = index[max_loc]
-        max_pfactor = np.exp(2 * np.pi * 1j * (subpixel_shift * kx / npad))
-
-        # Determine integer shift via cross correlation
-        conjugate = np.conj(ref_line_pad_ft) * line_pad_ft * max_pfactor
-        xcorr = np.abs(np.fft.fftshift(np.fft.ifft(np.fft.ifftshift(conjugate))))
-        max_loc = np.argmax(xcorr)
-
-        integer_shift = max_loc
-        integer_shift = integer_shift - midpoint
-
-        # Calculate full shift
-        shift = integer_shift + subpixel_shift
-        return -shift
-
-    if cl_ref_index is None:
-        cl_ref_index = stack.data.shape[0] // 2
-
-    yshifts = np.zeros(stack.data.shape[0])
-    ref_cm_line = stack.data[cl_ref_index].sum(0)
-
-    for i in tqdm.tqdm(range(stack.data.shape[0])):
-        if i == cl_ref_index:
-            continue
-        curr_cm_line = stack.data[i].sum(0)
-        yshifts[i] = align_line(ref_cm_line, curr_cm_line, cl_resolution, cl_div_factor)
-    return yshifts
-
-
-def calculate_shifts_conservation_of_mass(
-    stack: "TomoStack",
-    xrange: tuple[int, int] | None = None,
-    p: int = 20,
-) -> np.ndarray:
-    """
-    Calculate shifts parallel to the tilt axis using conservation of mass.
-
-    Slices which have the highest ratio of total mass to mass variance
-    and their location are returned.
-
-    Parameters
-    ----------
-    stack
-        Tilt series to be aligned.
-    xrange
-        The range for performing alignment
-    p
-        Padding element
-
-    Returns
-    -------
-    xshifts : :py:class:`~numpy.ndarray`
-        Calculated shifts parallel to tilt axis.
-
-    Group
-    -----
-    align
-    """
-    logger.info("Refinining X-shifts using conservation of mass method")
-    ntilts, _, nx = stack.data.shape
-
-    if xrange is None:
-        xrange = (round(nx / 5), round(4 / 5 * nx))
-    else:
-        xrange = (round(xrange[0]) + p, round(xrange[1]) - p)
-
-    xshifts = np.zeros([ntilts, 1])
-    total_mass = np.zeros([ntilts, xrange[1] - xrange[0] + 2 * p + 1])
-
-    for i in range(ntilts):
-        total_mass[i, :] = np.sum(
-            stack.data[i, :, xrange[0] - p - 1 : xrange[1] + p],
-            0,
-        )
-
-    mean_mass = np.mean(total_mass[:, p:-p], 0)
-
-    for i in range(ntilts):
-        s = 0
-        for j in range(-p, p):
-            resid = np.linalg.norm(mean_mass - total_mass[i, p + j : -p + j])
-            if resid < s or j == -p:
-                s = resid
-                xshifts[i] = -j
-    return xshifts[:, 0]
+        Group
+        -----
+        align
+        """
+        npix = len(line)
+        start_index = (paddedsize - npix) // 2
+        end_index = start_index + npix
+        padded_line = np.zeros(paddedsize)
+        padded_line[start_index:end_index] = line
+        return padded_line
 
 
 def align_stack(

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -3,6 +3,7 @@
 # pyright: reportPossiblyUnboundVariable=false
 
 import logging
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Literal, Union, cast
 
 import astra
@@ -36,6 +37,119 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 CL_RES_THRESHOLD = 0.5  # threshold for common line registration method
+
+
+class AlignmentMethod(ABC):
+    """Abstract Base class for Alignment methods."""
+
+    @abstractmethod
+    def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
+        """
+        Calculate the shifts to be applied to the stack.
+
+        Parameters
+        ----------
+        stack
+            The image series to be aligned
+        """
+
+
+class StackAligner:
+    """Class for aligning a TomoStack using a specified alignment strategy."""
+
+    def __init__(self, stack: "TomoStack"):
+        self.stack = stack
+        self.shifts = None
+
+    def align(
+        self,
+        align_method: AlignmentMethod,
+        shift_method: str = "fourier",
+    ) -> "TomoStack":
+        """Align stack using the specified strategy and method for applying shifts."""
+        # 1. Calculate
+        self.shifts = align_method.calculate(self.stack)
+
+        # 2. Apply (Determine if CUDA is needed automatically)
+        if hasattr(align_method, "cuda") and align_method.cuda and has_cupy:
+            return apply_shifts_cuda(self.stack, self.shifts, shift_method)
+        return apply_shifts(self.stack, self.shifts, shift_method)
+
+
+class PhaseCorrelationAligner(AlignmentMethod):
+    """Phase correlation alignment strategy."""
+
+    def __init__(
+        self,
+        start=None,
+        upsample_factor=3,
+        cuda=False,
+        show_progressbar=True,
+    ):
+        self.start = start
+        self.upsample_factor = upsample_factor
+        self.cuda = cuda
+        self.show_progress = show_progressbar
+
+    def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
+        """
+        Calculate shifts using the phase correlation algorithm.
+
+        Parameters
+        ----------
+        stack
+            The image series to be aligned
+        start
+            Position in tilt series to use as starting point for the alignment
+        show_progressbar
+            Enable/disable progress bar
+        upsample_factor
+            Factor by which to resample the data
+        cuda
+            Enable/disable the use of GPU-accelerated processes using CUDA
+
+        Returns
+        -------
+        shifts : :py:class:`~numpy.ndarray`
+            The X- and Y-shifts to be applied to each image
+
+        Group
+        -----
+        align
+        """
+        if has_cupy and astra.use_cuda() and self.cuda:
+            shifts = _cupy_calculate_shifts(
+                stack,
+                self.start,
+                self.show_progressbar,
+                self.upsample_factor,
+            )
+
+        else:
+            shifts = np.zeros((stack.data.shape[0], 2))
+            with tqdm.tqdm(
+                total=stack.data.shape[0] - 1,
+                desc="Calculating shifts",
+                disable=not self.show_progressbar,
+            ) as pbar:
+                for i in range(self.start, 0, -1):
+                    shift = pcc(
+                        stack.data[i],
+                        stack.data[i - 1],
+                        upsample_factor=self.upsample_factor,
+                    )[0]
+                    shifts[i - 1] = shifts[i] + shift
+                    pbar.update(1)
+
+                for i in range(self.start, stack.data.shape[0] - 1):
+                    shift = pcc(
+                        stack.data[i],
+                        stack.data[i + 1],
+                        upsample_factor=self.upsample_factor,
+                    )[0]
+                    shifts[i + 1] = shifts[i] + shift
+                    pbar.update(1)
+        return shifts
 
 
 def get_best_slices(stack: "TomoStack", nslices: int) -> np.ndarray:
@@ -623,69 +737,6 @@ def _cupy_calculate_shifts(stack, start, show_progressbar, upsample_factor):
     return shifts
 
 
-def calculate_shifts_pc(
-    stack: "TomoStack",
-    start: int,
-    show_progressbar: bool = False,
-    upsample_factor: int = 3,
-    cuda: bool = False,
-) -> np.ndarray:
-    """
-    Calculate shifts using the phase correlation algorithm.
-
-    Parameters
-    ----------
-    stack
-        The image series to be aligned
-    start
-        Position in tilt series to use as starting point for the alignment
-    show_progressbar
-        Enable/disable progress bar
-    upsample_factor
-        Factor by which to resample the data
-    cuda
-        Enable/disable the use of GPU-accelerated processes using CUDA
-
-    Returns
-    -------
-    shifts : :py:class:`~numpy.ndarray`
-        The X- and Y-shifts to be applied to each image
-
-    Group
-    -----
-    align
-    """
-    if has_cupy and astra.use_cuda() and cuda:
-        shifts = _cupy_calculate_shifts(stack, start, show_progressbar, upsample_factor)
-
-    else:
-        shifts = np.zeros((stack.data.shape[0], 2))
-        with tqdm.tqdm(
-            total=stack.data.shape[0] - 1,
-            desc="Calculating shifts",
-            disable=not show_progressbar,
-        ) as pbar:
-            for i in range(start, 0, -1):
-                shift = pcc(
-                    stack.data[i],
-                    stack.data[i - 1],
-                    upsample_factor=upsample_factor,
-                )[0]
-                shifts[i - 1] = shifts[i] + shift
-                pbar.update(1)
-
-            for i in range(start, stack.data.shape[0] - 1):
-                shift = pcc(
-                    stack.data[i],
-                    stack.data[i + 1],
-                    upsample_factor=upsample_factor,
-                )[0]
-                shifts[i + 1] = shifts[i] + shift
-                pbar.update(1)
-
-    return shifts
-
-
 def calculate_shifts_stackreg(
     stack: "TomoStack",
     start: int | None,
@@ -819,7 +870,6 @@ def align_stack(  # noqa: PLR0913
     p: int = 20,
     nslices: int = 20,
     cuda: bool = False,
-    upsample_factor: int = 3,
     com_ref_index: int | None = None,
     cl_ref_index: int | None = None,
     cl_resolution: float = 0.05,
@@ -939,21 +989,6 @@ def align_stack(  # noqa: PLR0913
         # calculate_shifts_com returns y-shifts (perpendicular to tilt axis)
         shifts[:, 1] = calculate_shifts_conservation_of_mass(stack, xrange, p)
         shifts[:, 0] = calculate_shifts_com(stack, nslices)
-    elif method == AlignmentMethod.PC:
-        if cuda:
-            logger.info(  # pragma: no cover
-                "Performing stack registration using "
-                "CUDA-accelerated phase correlation",
-            )
-        else:
-            logger.info("Performing stack registration using phase correlation")
-        shifts = calculate_shifts_pc(
-            stack,
-            start,
-            show_progressbar,
-            upsample_factor,
-            cuda,
-        )
     elif method == AlignmentMethod.STACK_REG:
         logger.info("Performing stack registration using PyStackReg")
         shifts = calculate_shifts_stackreg(stack, start, show_progressbar)

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -18,7 +18,7 @@ from skimage.filters import sobel
 from skimage.registration import phase_cross_correlation as pcc
 from skimage.transform import hough_line, hough_line_peaks
 
-from etspy import AlignmentMethod, AlignmentMethodType
+from etspy import AlignmentMethodType
 
 if TYPE_CHECKING:
     from hyperspy.misc.utils import DictionaryTreeBrowser as Dtb

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -334,8 +334,8 @@ class CoMAligner(AlignmentStrategy):
     def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
         logger.info("Performing stack registration using center of mass method")
         shifts = np.zeros([stack.data.shape[0], 2])
-        # calculate_shifts_conservation_of_mass returns x-shifts (parallel to tilt axis)
-        # calculate_shifts_com returns y-shifts (perpendicular to tilt axis)
+        # _calculate_shifts_conservation_of_mass: x-shifts (parallel to tilt axis)
+        # _calculate_shifts_com: y-shifts (perpendicular to tilt axis)
         shifts[:, 1] = self._calculate_shifts_conservation_of_mass(
             stack,
             self.xrange,
@@ -909,127 +909,10 @@ def calculate_shifts_conservation_of_mass(
     return xshifts[:, 0]
 
 
-def calculate_shifts_com(stack: "TomoStack", nslices: int) -> np.ndarray:
-    """
-    Align stack using a center of mass method.
-
-    Data is first registered using PyStackReg. Then, the shifts
-    perpendicular to the tilt axis are refined by a center of
-    mass analysis.
-
-    Parameters
-    ----------
-    stack
-        The image series to be aligned
-
-    nslices
-        Number of slices to return
-
-    Returns
-    -------
-    shifts : :py:class:`~numpy.ndarray`
-        The X- and Y-shifts to be applied to each image
-
-    Group
-    -----
-    align
-    """
-    logger.info("Refinining Y-shifts using center of mass method")
-    slices = get_best_slices(stack, nslices)
-
-    angles = stack.tilts.data.squeeze()
-    ntilts, _, _ = stack.data.shape
-    thetas = np.pi * cast("np.ndarray", angles) / 180
-
-    coms = get_coms(stack, slices)
-    i_tilts = np.eye(ntilts)
-    gam = np.array([np.cos(thetas), np.sin(thetas)]).T
-    gam = np.dot(gam, np.linalg.pinv(gam)) - i_tilts
-    b = np.dot(gam, coms)
-
-    cx = np.linalg.lstsq(gam, b, rcond=-1)[0]
-
-    yshifts = -cx[:, 0]
-    return yshifts
-
-
-def calc_shifts_com_cl(
-    stack: "TomoStack",
-    com_ref_index: int,
-    cl_ref_index: int | None = None,
-    cl_resolution: float = 0.05,
-    cl_div_factor: int = 8,
-) -> np.ndarray:
-    """
-    Calculate shifts using combined center of mass and common line methods.
-
-    Center of mass aligns stack perpendicular to the tilt axis and
-    common line is used to align the stack parallel to the tilt axis.
-
-    Parameters
-    ----------
-    stack
-        Tilt series to be aligned
-    com_ref_index
-        Reference slice for center of mass alignment.  All other slices
-        will be aligned to this reference.
-    cl_ref_index
-        Reference slice for common line alignment.  All other slices
-        will be aligned to this reference. If not provided the projection
-        closest to the middle of the stack will be chosen.
-    cl_resolution
-        Resolution for subpixel common line alignment. Default is 0.05.
-        Should be less than 0.5.
-    cl_div_factor
-        Factor which determines the number of iterations of common line
-        alignment to perform.  Default is 8.
-
-    Returns
-    -------
-    reg : :py:class:`~numpy.ndarray`
-        The X- and Y-shifts to be applied to each image
-
-    Group
-    -----
-    align
-    """
-
-    def calc_yshifts(stack, com_ref):
-        ntilts = stack.data.shape[0]
-        ali_x = stack.deepcopy()
-        coms = np.zeros(ntilts)
-        yshifts = np.zeros_like(coms)
-
-        for i in tqdm.tqdm(range(ntilts)):
-            im = ali_x.data[i, :, :]
-            coms[i], _ = ndimage.center_of_mass(im)
-            yshifts[i] = com_ref - coms[i]
-        return yshifts
-
-    if cl_resolution >= CL_RES_THRESHOLD:
-        msg = f"Resolution should be less than {CL_RES_THRESHOLD}"
-        raise ValueError(msg)
-
-    logger.info("Center of mass reference slice: %s", com_ref_index)
-    logger.info("Common line reference slice: %s", cl_ref_index)
-    xshifts = np.zeros(stack.data.shape[0])
-    yshifts = np.zeros(stack.data.shape[0])
-    yshifts = calc_yshifts(stack, com_ref_index)
-    xshifts = calc_shifts_cl(stack, cl_ref_index, cl_resolution, cl_div_factor)
-    shifts = np.stack([yshifts, xshifts], axis=1)
-    return shifts
-
-
 def align_stack(
     stack: "TomoStack",
     method: AlignmentMethodType,
     start: int | None,
-    shift_type: Literal["fourier", "interp"] = "fourier",
-    cuda: bool = False,
-    com_ref_index: int | None = None,
-    cl_ref_index: int | None = None,
-    cl_resolution: float = 0.05,
-    cl_div_factor: int = 8,
 ) -> "TomoStack":
     """
     Compute the shifts for spatial registration.
@@ -1138,33 +1021,9 @@ def align_stack(
         )  # Use the slice closest to the midpoint if start is not provided
     start = cast("int", start)  # explicit type cast for type checking
 
-    if method == AlignmentMethod.COM_CL:
-        logger.info(
-            "Performing stack registration using combined "
-            "center of mass and common line methods",
-        )
-        if com_ref_index is None:
-            com_ref_index = stack.data.shape[1] // 2
-        if cl_ref_index is None:
-            cl_ref_index = stack.data.shape[0] // 2
-
-        # explicit type casts for type checking
-        com_ref_index = cast("int", com_ref_index)
-        cl_ref_index = cast("int", cl_ref_index)
-
-        shifts = calc_shifts_com_cl(
-            stack,
-            com_ref_index,
-            cl_ref_index,
-            cl_resolution,
-            cl_div_factor,
-        )
-    else:
-        msg = f"Invalid alignment method {method}"
-        raise ValueError(msg)
-    aligned = apply_shifts(stack, shifts, shift_type, cuda=cuda)
-    logger.info("Stack registration complete")
-    return aligned
+    msg = f"Invalid alignment method {method}"
+    raise ValueError(msg)
+    return
 
 
 def tilt_com(

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -866,7 +866,7 @@ class CommonLineAligner(StackAligner):
         xshifts = np.zeros(self.stack.data.shape[0])
         yshifts = np.zeros(self.stack.data.shape[0])
         yshifts = self._calc_yshifts(self.com_ref_index)
-        xshifts = self._calc_shifts_cl(
+        xshifts = self.calc_shifts_cl(
             self.cl_ref_index,
             self.cl_resolution,
             self.cl_div_factor,
@@ -875,6 +875,7 @@ class CommonLineAligner(StackAligner):
         return shifts
 
     def _calc_yshifts(self, com_ref):
+        """Calculate using center of mass tracking."""
         ntilts = self.stack.data.shape[0]
         coms = np.zeros(ntilts)
         yshifts = np.zeros_like(coms)
@@ -885,7 +886,7 @@ class CommonLineAligner(StackAligner):
             yshifts[i] = com_ref - coms[i]
         return yshifts
 
-    def _calc_shifts_cl(
+    def calc_shifts_cl(
         self,
         cl_ref_index: int | None,
         cl_resolution: float,
@@ -922,8 +923,8 @@ class CommonLineAligner(StackAligner):
             npad = len(ref_line) * 2 - 1
 
             # Pad with zeros while preserving the center location
-            ref_line_pad = self._pad_line(ref_line, npad)
-            line_pad = self._pad_line(line, npad)
+            ref_line_pad = self.pad_line(ref_line, npad)
+            line_pad = self.pad_line(line, npad)
 
             niters = int(
                 np.abs(np.floor(np.log(cl_resolution) / np.log(cl_div_factor))),
@@ -987,7 +988,7 @@ class CommonLineAligner(StackAligner):
             )
         return yshifts
 
-    def _pad_line(self, line: np.ndarray, paddedsize: int) -> np.ndarray:
+    def pad_line(self, line: np.ndarray, paddedsize: int) -> np.ndarray:
         """
         Pad a 1D array for FFT treatment without altering center location.
 

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -232,6 +232,7 @@ class StackAligner(ABC):
         start: int | None = None,
         use_cuda: bool | None = False,
         show_progressbar: bool = False,
+        **kwargs,
     ):
         use_cuda = cast("bool", use_cuda)
         self.stack = stack
@@ -242,6 +243,7 @@ class StackAligner(ABC):
         self.start = start
         self.use_cuda = use_cuda
         self.show_progressbar = show_progressbar
+        self.kwargs = kwargs
 
     def align(
         self,
@@ -312,9 +314,9 @@ class PhaseCorrelationAligner(StackAligner):
         self,
         stack: "TomoStack",
         start: int = 0,
-        upsample_factor: int = 3,
         use_cuda: bool = False,
         show_progressbar: bool = True,
+        **kwargs,
     ):
         super().__init__(
             stack=stack,
@@ -322,7 +324,7 @@ class PhaseCorrelationAligner(StackAligner):
             use_cuda=use_cuda,
             show_progressbar=show_progressbar,
         )
-        self.upsample_factor = upsample_factor
+        self.upsample_factor = kwargs.get("upsample_factor", 3)
 
     def calculate_shifts(self) -> np.ndarray:
         """
@@ -640,9 +642,7 @@ class CoMAligner(StackAligner):
         stack: "TomoStack",
         start: int = 0,
         show_progressbar: bool = True,
-        xrange: tuple[int, int] | None = None,
-        p: int = 20,
-        nslices: int = 20,
+        **kwargs,
     ):
         super().__init__(
             stack=stack,
@@ -652,9 +652,9 @@ class CoMAligner(StackAligner):
         )
         self.start = start
         self.show_progressbar = show_progressbar
-        self.xrange = xrange
-        self.p = p
-        self.nslices = nslices
+        self.xrange = kwargs.get("xrange")
+        self.p = kwargs.get("p", 20)
+        self.nslices = kwargs.get("nslices", 20)
 
     def calculate_shifts(self) -> np.ndarray:
         """Calculate shifts using center of mass tracking method."""
@@ -805,10 +805,7 @@ class CommonLineAligner(StackAligner):
         stack: "TomoStack",
         start: int = 0,
         show_progressbar: bool = True,
-        com_ref_index: int | None = None,
-        cl_ref_index: int | None = None,
-        cl_resolution: float = 0.05,
-        cl_div_factor: int = 8,
+        **kwargs,
     ):
         super().__init__(
             stack=stack,
@@ -816,10 +813,10 @@ class CommonLineAligner(StackAligner):
             use_cuda=False,
             show_progressbar=show_progressbar,
         )
-        self.com_ref_index = com_ref_index
-        self.cl_ref_index = cl_ref_index
-        self.cl_resolution = cl_resolution
-        self.cl_div_factor = cl_div_factor
+        self.com_ref_index = kwargs.get("com_ref_index")
+        self.cl_ref_index = kwargs.get("cl_ref_index")
+        self.cl_resolution = kwargs.get("cl_resolution", 0.05)
+        self.cl_div_factor = kwargs.get("cl_div_factor", 8)
 
     def calculate_shifts(self) -> np.ndarray:
         """Calculate shifts using combined center of mass and common line methods."""

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -29,6 +29,10 @@ has_cupy = True
 try:
     import cupy as cp  # type: ignore
     from cupyx.scipy.ndimage import shift as shift_gpu
+
+    if not cp.is_available():
+        has_cupy = False
+
 except ImportError:
     has_cupy = False
 
@@ -41,8 +45,14 @@ CL_RES_THRESHOLD = 0.5  # threshold for common line registration method
 class AlignmentStrategy(ABC):
     """Abstract Base class for Alignment methods."""
 
-    def __init__(self, use_cuda: bool = False):
+    def __init__(
+        self,
+        use_cuda: bool | None = False,
+        show_progressbar: bool = False,
+    ):
+        use_cuda = cast("bool", use_cuda)
         self.use_cuda = use_cuda
+        self.show_progressbar = show_progressbar
 
     @abstractmethod
     def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
@@ -52,7 +62,10 @@ class AlignmentStrategy(ABC):
 class StackAligner:
     """Handles the orchestration of alignment."""
 
-    def __init__(self, stack: "TomoStack"):
+    def __init__(
+        self,
+        stack: "TomoStack",
+    ):
         self.stack = stack
 
     def align(
@@ -73,6 +86,34 @@ class StackAligner:
 
 
 class PhaseCorrelationAligner(AlignmentStrategy):
+    """
+    Aligner class for phase correlation (PC) strategy.
+
+    If `use_cuda` is False, shifts are determined using PC as implemented in
+    scikit-image. Based on:
+    Manuel Guizar-Sicairos, Samuel T. Thurman, and James R. Fienup.
+    Efficient subpixel image registration algorithms, Optics Letters vol. 33
+    (2008) pp. 156-158.
+    https://doi.org/10.1364/OL.33.000156
+
+    If `use_cuda` is True, shifts are determined using a custom implementation of the
+    same PC algorithm which is optimized for GPU-acceleration using CuPy and CUDA.
+
+    Initialiazer for phase correlation alignment strategy.
+
+    Atrributes
+    ----------
+    start : py:class:`~int`
+        Position in tilt series to use as starting point for the alignment
+    upsample_factor : py:class:`~int`
+        Factor by which to resample the data for phase correlation
+    use_cuda : py:class:`~bool`
+        Enable/disable the use of GPU-accelerated processes using CUDA
+    show_progressbar : py:class:`~bool`
+        Enable/disable progress bar
+
+    """
+
     def __init__(
         self,
         start: int = 0,
@@ -80,10 +121,9 @@ class PhaseCorrelationAligner(AlignmentStrategy):
         use_cuda: bool = False,
         show_progressbar: bool = True,
     ):
-        super().__init__(use_cuda=use_cuda)
+        super().__init__(use_cuda=use_cuda, show_progressbar=show_progressbar)
         self.start = start
         self.upsample_factor = upsample_factor
-        self.show_progressbar = show_progressbar
 
     def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
         """
@@ -91,16 +131,8 @@ class PhaseCorrelationAligner(AlignmentStrategy):
 
         Parameters
         ----------
-        stack
-            The image series to be aligned
-        start
-            Position in tilt series to use as starting point for the alignment
-        show_progressbar
-            Enable/disable progress bar
-        upsample_factor
-            Factor by which to resample the data
-        cuda
-            Enable/disable the use of GPU-accelerated processes using CUDA
+        stack : :py:class:`~TomoStack`
+            The image stack to be aligned
 
         Returns
         -------
@@ -141,6 +173,7 @@ class PhaseCorrelationAligner(AlignmentStrategy):
         return shifts
 
     def _cupy_calculate_shifts(self, stack):
+        """Calculate shifts of stack using CUDA-implementation of phase correlation."""
         stack_cp = cp.array(stack.data)
         shifts = cp.zeros([stack_cp.shape[0], 2])
         ref_cp = stack_cp[0]
@@ -171,6 +204,7 @@ class PhaseCorrelationAligner(AlignmentStrategy):
         return shifts
 
     def _cupy_phase_correlate(self, ref_cp, mov_cp, shape):
+        """CUDA-implementation of phase correlation."""
         # missing coverage b/c of CUDA
         ref_fft = cp.fft.fftn(ref_cp)
         mov_fft = cp.fft.fftn(mov_cp)
@@ -223,6 +257,34 @@ class PhaseCorrelationAligner(AlignmentStrategy):
         upsample_factor,
         axis_offsets,
     ):
+        """
+        CuPy-implmentation of DFT upsampling algorithm.
+
+        This code is a CuPy adaptation of the algorithm used in:
+
+        scikit-image.registration._phase_cross_correlation.
+        https://github.com/scikit-image/scikit-image/blob/v0.26.0/src/skimage/registration/_phase_cross_correlation.py
+
+        It is intended to achieve sub-pixel precision while avoiding padding of the
+        dataset and the related risk of memory limitations. See scikit-image source for
+        more detail.
+
+        Parameters
+        ----------
+        data : :py:class:`~numpy.ndarray`
+            DFT of original data to upsample.
+        upsampled_region_size : :py:class:`~int`
+            The size of the region to be sampled.
+        upsample_factor : :py:class:`~int`
+            Factor by which to upsample the DFT.
+        axis_offsets : :py:class:`~list` of :py:class:`~int`
+            The offsets of the region to be sampled.
+
+        Returns
+        -------
+        output : :py:class:`~numpy.ndarray`
+            The upsampled DFT of the specified region.
+        """
         # missing coverage because of CUDA
         upsampled_region_size = [
             upsampled_region_size,

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -1016,20 +1016,27 @@ class CommonLineAligner(StackAligner):
         return padded_line
 
 
-def tilt_com(
-    stack: "TomoStack",
-    slices: np.ndarray | None = None,
-    nslices: int | None = None,
-) -> "TomoStack":
-    """
+class TiltAligner(ABC):
+    """Abstract class for performing tilt axis alignment."""
+
+    def __init__(self, stack, **kwargs):
+        self.stack = stack
+        self.kwargs = kwargs
+
+    @abstractmethod
+    def align_tilt_axis(self) -> "TomoStack":
+        """Align the tilt axis using the selected strategy."""
+
+
+class TiltCOMAligner(TiltAligner):
+    """Tilt alignment class for center of mass method.
+
     Perform tilt axis alignment using center of mass (CoM) tracking.
 
     Compares path of specimen to the path expected for an ideal cylinder
 
     Parameters
     ----------
-    stack
-        TomoStack containing the tilt series data
     slices
         Locations at which to perform the Center of Mass analysis. If not
         provided, an appropriate list of slices will be automatically determined.
@@ -1049,84 +1056,105 @@ def tilt_com(
     align
     """
 
-    def com_motion(theta, r, x0, z0):
-        return r - x0 * np.cos(theta) - z0 * np.sin(theta)
+    def __init__(self, stack, **kwargs):
+        super().__init__(stack, **kwargs)
+        self.slices = kwargs.get("slices")
+        self.nslices = kwargs.get("nslices")
 
-    def fit_line(x, m, b):
-        return m * x + b
+    def align_tilt_axis(self) -> "TomoStack":
+        """Align tilt axis with center of mass tracking."""
 
-    _, ny, nx = stack.data.shape
-    nx_threshold = 3
+        def com_motion(theta, r, x0, z0):
+            return r - x0 * np.cos(theta) - z0 * np.sin(theta)
 
-    if np.all(stack.tilts.data == 0):
-        msg = (
-            "Tilts are not defined in stack.tilts (values were all zeros). "
-            "Please set tilt values before alignment."
+        def fit_line(x, m, b):
+            return m * x + b
+
+        _, ny, nx = self.stack.data.shape
+        nx_threshold = 3
+
+        if np.all(self.stack.tilts.data == 0):
+            msg = (
+                "Tilts are not defined in stack.tilts (values were all zeros). "
+                "Please set tilt values before alignment."
+            )
+            raise ValueError(msg)
+
+        if nx < nx_threshold:
+            msg = (
+                f"Dataset is only {self.stack.data.shape[2]} pixels in x dimension. "
+                "This method cannot be used."
+            )
+            raise ValueError(msg)
+
+        # Determine the best slice locations for the analysis
+        if self.slices is None:
+            if self.nslices is None:
+                self.nslices = int(0.1 * nx)
+                self.nslices = max(min(self.nslices, 50), 3)  # clamp nslices to [3, 50]
+            else:
+                if self.nslices > nx:
+                    msg = "nslices is greater than the X-dimension of the data."
+                    raise ValueError(msg)
+                if self.nslices > 0.3 * nx:
+                    self.nslices = int(0.3 * nx)
+                    msg = (
+                        "nslices is greater than 30% of number of x pixels. "
+                        f"Using {self.nslices} slices instead."
+                    )
+                    logger.warning(msg)
+
+            self.slices = get_best_slices(self.stack, self.nslices)
+            logger.info("Performing alignments using best %s slices", self.nslices)
+
+        self.slices = np.sort(self.slices)
+
+        coms = get_coms(self.stack, self.slices)
+        thetas = (
+            np.pi * self.stack.tilts.data.squeeze() / 180.0
+        )  # remove length 1 dimension
+
+        r, x0, z0 = (
+            np.zeros(len(self.slices)),
+            np.zeros(len(self.slices)),
+            np.zeros(
+                len(self.slices),
+            ),
         )
-        raise ValueError(msg)
 
-    if nx < nx_threshold:
-        msg = (
-            f"Dataset is only {stack.data.shape[2]} pixels in x dimension. "
-            "This method cannot be used."
-        )
-        raise ValueError(msg)
-
-    # Determine the best slice locations for the analysis
-    if slices is None:
-        if nslices is None:
-            nslices = int(0.1 * nx)
-            nslices = max(min(nslices, 50), 3)  # clamp nslices to [3, 50]
-        else:
-            if nslices > nx:
-                msg = "nslices is greater than the X-dimension of the data."
-                raise ValueError(msg)
-            if nslices > 0.3 * nx:
-                nslices = int(0.3 * nx)
-                msg = (
-                    "nslices is greater than 30% of number of x pixels. "
-                    f"Using {nslices} slices instead."
-                )
-                logger.warning(msg)
-
-        slices = get_best_slices(stack, nslices)
-        logger.info("Performing alignments using best %s slices", nslices)
-
-    slices = np.sort(slices)
-
-    coms = get_coms(stack, slices)
-    thetas = np.pi * stack.tilts.data.squeeze() / 180.0  # remove length 1 dimension
-
-    r, x0, z0 = np.zeros(len(slices)), np.zeros(len(slices)), np.zeros(len(slices))
-
-    for idx, _ in enumerate(slices):
-        r[idx], x0[idx], z0[idx] = optimize.curve_fit(
-            com_motion,
-            xdata=thetas,
-            ydata=coms[:, idx],
-            p0=[0, 0, 0],
+        for idx, _ in enumerate(self.slices):
+            r[idx], x0[idx], z0[idx] = optimize.curve_fit(
+                com_motion,
+                xdata=thetas,
+                ydata=coms[:, idx],
+                p0=[0, 0, 0],
+            )[0]
+        slope, intercept = optimize.curve_fit(
+            fit_line,
+            xdata=r,
+            ydata=self.slices,
+            p0=[0, 0],
         )[0]
-    slope, intercept = optimize.curve_fit(fit_line, xdata=r, ydata=slices, p0=[0, 0])[0]
-    tilt_shift = (ny / 2 - intercept) / slope
-    tilt_rotation = -(180 * np.arctan(1 / slope) / np.pi)
+        tilt_shift = (ny / 2 - intercept) / slope
+        tilt_rotation = -(180 * np.arctan(1 / slope) / np.pi)
 
-    final = cast("TomoStack", stack.trans_stack(yshift=tilt_shift, angle=tilt_rotation))
+        final = cast(
+            "TomoStack",
+            self.stack.trans_stack(
+                yshift=tilt_shift,
+                angle=tilt_rotation,
+            ),
+        )
 
-    logger.info("Calculated tilt-axis shift %.2f", tilt_shift)
-    logger.info("Calculated tilt-axis rotation %.2f", tilt_rotation)
+        logger.info("Calculated tilt-axis shift %.2f", tilt_shift)
+        logger.info("Calculated tilt-axis rotation %.2f", tilt_rotation)
 
-    return final
+        return final
 
 
-def tilt_maximage(
-    stack: "TomoStack",
-    limit: float = 10,
-    delta: float = 0.1,
-    plot_results: bool = False,
-    also_shift: bool = False,
-    shift_limit: float = 20,
-) -> "TomoStack":
-    """
+class TiltMaxImageAligner(TiltAligner):
+    """Tilt alignment class for maximum image method.
+
     Perform automated determination of the tilt axis of a TomoStack.
 
     The projected maximum image used to determine the tilt axis by a
@@ -1158,59 +1186,70 @@ def tilt_maximage(
     -----
     align
     """
-    image = stack.data.max(0)
-    image = image.astype("float32")
-    edges = sobel(image)
 
-    # Apply Canny edge detector for further edge enhancement
-    edges = canny(edges)
+    def __init__(self, stack, **kwargs):
+        super().__init__(stack, **kwargs)
+        self.limit = kwargs.get("limit", 10)
+        self.delta = kwargs.get("delta", 0.1)
+        self.plot_results = kwargs.get("plot_results", False)
+        self.also_shift = kwargs.get("also_shift", False)
+        self.shift_limit = kwargs.get("shift_limit", 20.0)
 
-    # Perform Hough transform to detect lines
-    angles = np.pi * np.arange(-limit, limit, delta) / 180.0
-    h, theta, d = hough_line(edges, angles)
+    def align_tilt_axis(self) -> "TomoStack":
+        """Align tilt axis with center of mass tracking."""
+        image = self.stack.data.max(0)
+        image = image.astype("float32")
+        edges = sobel(image)
 
-    # Find peaks in Hough space
-    _, angles, dists = hough_line_peaks(h, theta, d, num_peaks=5)
+        # Apply Canny edge detector for further edge enhancement
+        edges = canny(edges)
 
-    # Calculate average angle from detected lines
-    rotation_angle = np.degrees(np.mean(angles))
+        # Perform Hough transform to detect lines
+        angles = np.pi * np.arange(-self.limit, self.limit, self.delta) / 180.0
+        h, theta, d = hough_line(edges, angles)
 
-    if plot_results:
-        _, ax = plt.subplots(1)
-        ax.imshow(image, cmap="gray")
+        # Find peaks in Hough space
+        _, angles, dists = hough_line_peaks(h, theta, d, num_peaks=5)
 
-        for i in range(len(angles)):
-            (x0, y0) = dists[i] * np.array([np.cos(angles[i]), np.sin(angles[i])])
-            ax.axline((x0, y0), slope=np.tan(angles[i] + np.pi / 2))
+        # Calculate average angle from detected lines
+        rotation_angle = np.degrees(np.mean(angles))
 
-        plt.tight_layout()
+        if self.plot_results:
+            _, ax = plt.subplots(1)
+            ax.imshow(image, cmap="gray")
 
-    ali = cast("TomoStack", stack.trans_stack(angle=-rotation_angle))
-    tomo_meta = cast("Dtb", ali.metadata.Tomography)
-    tomo_meta.tiltaxis = -rotation_angle
+            for i in range(len(angles)):
+                (x0, y0) = dists[i] * np.array([np.cos(angles[i]), np.sin(angles[i])])
+                ax.axline((x0, y0), slope=np.tan(angles[i] + np.pi / 2))
 
-    logger.info("Calculated tilt-axis rotation %.2f", -rotation_angle)
+            plt.tight_layout()
 
-    if also_shift:
-        idx = ali.data.shape[2] // 2
-        shifts = np.arange(-shift_limit, shift_limit, 1)
-        nshifts = shifts.shape[0]
-        shifted = ali.isig[0:nshifts, :].deepcopy()
-        for i in range(nshifts):
-            shifted.data[:, :, i] = np.roll(
-                ali.isig[idx : idx + 1, :].data.squeeze(),
-                int(shifts[i]),
-            )
-        shifted_rec = shifted.reconstruct("SIRT", 100, constrain=True)
-        image_sum = cast("BaseSignal", shifted_rec.sum(axis=(1, 2)))
-        tilt_shift = shifts[image_sum.data.argmin()]
-        tilt_shift = cast("float", tilt_shift)
-        ali = cast("TomoStack", ali.trans_stack(yshift=-tilt_shift))
-        tomo_meta.yshift = -tilt_shift
+        ali = cast("TomoStack", self.stack.trans_stack(angle=-rotation_angle))
+        tomo_meta = cast("Dtb", ali.metadata.Tomography)
+        tomo_meta.tiltaxis = -rotation_angle
 
-        logger.info("Calculated tilt-axis shift %.2f", -tilt_shift)
+        logger.info("Calculated tilt-axis rotation %.2f", -rotation_angle)
 
-    return ali
+        if self.also_shift:
+            idx = ali.data.shape[2] // 2
+            shifts = np.arange(-self.shift_limit, self.shift_limit, 1)
+            nshifts = shifts.shape[0]
+            shifted = ali.isig[0:nshifts, :].deepcopy()
+            for i in range(nshifts):
+                shifted.data[:, :, i] = np.roll(
+                    ali.isig[idx : idx + 1, :].data.squeeze(),
+                    int(shifts[i]),
+                )
+            shifted_rec = shifted.reconstruct("SIRT", 100, constrain=True)
+            image_sum = cast("BaseSignal", shifted_rec.sum(axis=(1, 2)))
+            tilt_shift = shifts[image_sum.data.argmin()]
+            tilt_shift = cast("float", tilt_shift)
+            ali = cast("TomoStack", ali.trans_stack(yshift=-tilt_shift))
+            tomo_meta.yshift = -tilt_shift
+
+            logger.info("Calculated tilt-axis shift %.2f", -tilt_shift)
+
+        return ali
 
 
 def align_to_other(

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -323,6 +323,7 @@ class PhaseCorrelationAligner(StackAligner):
             start=start,
             use_cuda=use_cuda,
             show_progressbar=show_progressbar,
+            **kwargs,
         )
         self.upsample_factor = kwargs.get("upsample_factor", 3)
 
@@ -549,13 +550,16 @@ class StackRegAligner(StackAligner):
         self,
         stack: "TomoStack",
         start: int = 0,
+        use_cuda: bool = False,
         show_progressbar: bool = True,
+        **kwargs,
     ):
         super().__init__(
             stack=stack,
             start=start,
-            use_cuda=False,
+            use_cuda=use_cuda,
             show_progressbar=show_progressbar,
+            **kwargs,
         )
 
     def calculate_shifts(self) -> np.ndarray:
@@ -641,14 +645,16 @@ class CoMAligner(StackAligner):
         self,
         stack: "TomoStack",
         start: int = 0,
+        use_cuda: bool = False,
         show_progressbar: bool = True,
         **kwargs,
     ):
         super().__init__(
             stack=stack,
             start=start,
-            use_cuda=False,
+            use_cuda=use_cuda,
             show_progressbar=show_progressbar,
+            **kwargs,
         )
         self.start = start
         self.show_progressbar = show_progressbar
@@ -804,14 +810,16 @@ class CommonLineAligner(StackAligner):
         self,
         stack: "TomoStack",
         start: int = 0,
+        use_cuda: bool = False,
         show_progressbar: bool = True,
         **kwargs,
     ):
         super().__init__(
             stack=stack,
             start=start,
-            use_cuda=False,
+            use_cuda=use_cuda,
             show_progressbar=show_progressbar,
+            **kwargs,
         )
         self.com_ref_index = kwargs.get("com_ref_index")
         self.cl_ref_index = kwargs.get("cl_ref_index")

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -4,7 +4,7 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Literal, Union, cast
+from typing import TYPE_CHECKING, Any, Literal, Union, cast
 
 import astra
 import matplotlib.pylab as plt
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
 has_cupy = True
 try:
     import cupy as cp  # type: ignore
-    from cupyx.scipy.ndimage import fourier_shift as fourier_shift_gpu
     from cupyx.scipy.ndimage import shift as shift_gpu
 except ImportError:
     has_cupy = False
@@ -66,7 +65,10 @@ class StackAligner:
 
         # Pass the strategy's CUDA preference to the applicator
         return apply_shifts(
-            self.stack, shifts, method=apply_method, cuda=strategy.use_cuda
+            self.stack,
+            shifts,
+            method=apply_method,
+            cuda=strategy.use_cuda,
         )
 
 
@@ -245,12 +247,14 @@ def apply_shifts(
         shifts = shifts.data
     shifts = cast("np.ndarray", shifts)
 
-    if len(shifts.data) != stack.data.shape[0]:
+    if len(shifts) != stack.data.shape[0]:
         msg = (
             f"Number of shifts ({len(shifts)}) is not consistent "
             f"with number of images in the stack ({stack.data.shape[0]})"
         )
         raise ValueError(msg)
+
+    shifts = xp.array(shifts)
 
     data = xp.array(shifted.data)
     if method.lower() == "interp":
@@ -263,8 +267,7 @@ def apply_shifts(
                 order=order,
             )
     elif method.lower() == "fourier":
-        fourier_shift_func = fourier_shift_gpu if cuda else ndimage.fourier_shift
-        _, ny, nx = data.shape
+        ntilts, ny, nx = data.shape
         y_pad_min = np.abs(shifts[:, 0]).max() + ny
         ny_pad = int(2 ** np.ceil(np.log2(y_pad_min)))
         y_pad_width = [(ny_pad - ny) // 2, (ny_pad - ny + 1) // 2]
@@ -281,14 +284,25 @@ def apply_shifts(
 
         _, ny, nx = data.shape
         data_fft = fft_module.fft2(data, axes=(1, 2))
-        for i in range(data.shape[0]):
-            data_fft[i, :, :] = fft_module.ifft2(
-                fourier_shift_func(
-                    data_fft[i],
-                    shift=[shifts[i, 0], shifts[i, 1]],
-                ),
-            )
-        data = xp.real(data_fft)
+        data_fft = cast("Any", data_fft)
+
+        # Create frequency grids
+        # v is vertical frequencies, u is horizontal
+        v = xp.fft.fftfreq(ny).reshape(1, ny, 1)
+        u = xp.fft.fftfreq(nx).reshape(1, 1, nx)
+
+        # Reshape shifts for broadcasting: (n_images, 1, 1)
+        sy = shifts[:, 0].reshape(ntilts, 1, 1)
+        sx = shifts[:, 1].reshape(ntilts, 1, 1)
+
+        # Compute the phase ramp
+        # The formula: exp(-2j * pi * (v * sy + u * sx))
+        phi = -2j * np.pi * (v * sy + u * sx)
+        kernel = xp.exp(phi)
+
+        # Apply shift and Inverse FFT
+        data = xp.fft.ifft2(data_fft * kernel, axes=(1, 2))
+        data = xp.real(data)
         slices = [
             slice(0, None),
         ]
@@ -301,6 +315,7 @@ def apply_shifts(
         raise ValueError(msg)
 
     shifted.data = cp.asnumpy(data) if cuda else data
+    shifts = cp.asnumpy(shifts) if cuda else shifts
     shifted.shifts.data = shifted.shifts.data + shifts
     return shifted
 

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -27,10 +27,9 @@ try:
     import cupy as cp  # type: ignore
     from cupyx.scipy.ndimage import shift as shift_gpu
 
-    if not cp.is_available():
-        has_cupy = False
+    has_gpu = cp.cuda.runtime.getDeviceCount() > 0
 
-except ImportError:
+except Exception:
     has_cupy = False
 
 logger = logging.getLogger(__name__)

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -42,54 +42,46 @@ CL_RES_THRESHOLD = 0.5  # threshold for common line registration method
 class AlignmentStrategy(ABC):
     """Abstract Base class for Alignment methods."""
 
+    def __init__(self, use_cuda: bool = False):
+        self.use_cuda = use_cuda
+
     @abstractmethod
     def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
-        """
-        Calculate the shifts to be applied to the stack.
-
-        Parameters
-        ----------
-        stack
-            The image series to be aligned
-        """
+        pass
 
 
 class StackAligner:
-    """Class for aligning a TomoStack using a specified alignment strategy."""
+    """Handles the orchestration of alignment."""
 
     def __init__(self, stack: "TomoStack"):
         self.stack = stack
-        self.shifts = None
 
     def align(
         self,
-        align_method: AlignmentStrategy,
-        shift_method: str = "fourier",
+        strategy: AlignmentStrategy,
+        apply_method: Literal["interp", "fourier"] = "fourier",
     ) -> "TomoStack":
-        """Align stack using the specified strategy and method for applying shifts."""
-        # 1. Calculate
-        self.shifts = align_method.calculate_shifts(self.stack)
+        # Strategy handles its own CUDA logic internally
+        shifts = strategy.calculate_shifts(self.stack)
 
-        # 2. Apply (Determine if CUDA is needed automatically)
-        if hasattr(align_method, "cuda") and align_method.cuda and has_cupy:
-            return apply_shifts(self.stack, self.shifts, shift_method, cuda=True)
-        return apply_shifts(self.stack, self.shifts, shift_method)
+        # Pass the strategy's CUDA preference to the applicator
+        return apply_shifts(
+            self.stack, shifts, method=apply_method, cuda=strategy.use_cuda
+        )
 
 
 class PhaseCorrelationAligner(AlignmentStrategy):
-    """Phase correlation alignment strategy."""
-
     def __init__(
         self,
-        start=None,
-        upsample_factor=3,
-        cuda=False,
-        show_progressbar=True,
+        start: int = 0,
+        upsample_factor: int = 3,
+        use_cuda: bool = False,
+        show_progressbar: bool = True,
     ):
+        super().__init__(use_cuda=use_cuda)
         self.start = start
         self.upsample_factor = upsample_factor
-        self.cuda = cuda
-        self.show_progress = show_progressbar
+        self.show_progressbar = show_progressbar
 
     def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
         """
@@ -117,7 +109,7 @@ class PhaseCorrelationAligner(AlignmentStrategy):
         -----
         align
         """
-        if has_cupy and astra.use_cuda() and self.cuda:
+        if has_cupy and astra.use_cuda() and self.use_cuda:
             shifts = _cupy_calculate_shifts(
                 stack,
                 self.start,

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -56,31 +56,64 @@ class AlignmentStrategy(ABC):
 
     @abstractmethod
     def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
-        pass
+        """
+        Calculate the alignment shifts using the selected strategy.
+
+        Parameters
+        ----------
+        stack : :py:class:`~TomoStack`
+            The TomoStack series to be analyzed.
+
+        Returns
+        -------
+        shifts : :py:class:`~numpy.ndarray`
+            An array of shape ``(n_images, 2)`` containing the calculated
+            shifts. The first column ``shifts[:, 0]`` should contain
+            Y-shifts (perpendicular to the tilt axis) and the second column
+            ``shifts[:, 1]`` should contain X-shifts (parallel to the tilt axis).
+
+        """
 
 
 class StackAligner:
-    """Handles the orchestration of alignment."""
+    """
+    Handles the orchestration of alignment.
+
+    Attributes
+    ----------
+    stack : :py:class:`~TomoStack`
+        The TomoStack to be aligned.
+
+    shifts : :py:class:`~numpy.ndarray`
+        The X- and Y-shifts to be applied to each image. Initialized
+        to an array of zeros with shape (n_images, 2).
+    """
 
     def __init__(
         self,
         stack: "TomoStack",
     ):
         self.stack = stack
+        self.shifts = np.zeros([stack.data.shape[0], 2])
 
     def align(
         self,
         strategy: AlignmentStrategy,
-        apply_method: Literal["interp", "fourier"] = "fourier",
+        shift_method: Literal["interp", "fourier"] = "fourier",
     ) -> "TomoStack":
-        # Strategy handles its own CUDA logic internally
-        shifts = strategy.calculate_shifts(self.stack)
+        """
+        Perform stack alignment.
+
+        Shifts are calculated using the provided strategy and then applied using the
+        specified shift method.
+        """
+        self.shifts = strategy.calculate_shifts(self.stack)
 
         # Pass the strategy's CUDA preference to the applicator
         return apply_shifts(
             self.stack,
-            shifts,
-            method=apply_method,
+            self.shifts,
+            method=shift_method,
             cuda=strategy.use_cuda,
         )
 
@@ -314,6 +347,36 @@ class PhaseCorrelationAligner(AlignmentStrategy):
 
 
 class StackRegAligner(AlignmentStrategy):
+    """
+    Aligner class for StackReg strategy.
+
+    Calculated rigid translational shifts using PyStackReg. PyStackReg is a Python port
+    of the StackReg plugin for ImageJ which uses a pyramidal approach to minimize the
+    least-squares difference in image intensity between a source and target image.
+    StackReg is described in:
+    P. Thevenaz, U.E. Ruttimann, M. Unser. A Pyramid Approach to
+    Subpixel Registration Based on Intensity, IEEE Transactions
+    on Image Processing vol. 7, no. 1, pp. 27-41, January 1998.
+    https://doi.org/10.1109/83.650848
+
+    Attributes
+    ----------
+    start
+        Position in tilt series to use as starting point for the alignment.
+        If ``None``, the slice closest to the midpoint will be used.
+    show_progressbar
+        Enable/disable progress bar
+
+    Returns
+    -------
+    shifts : :py:class:`~numpy.ndarray`
+        The X- and Y-shifts to be applied to each image
+
+    Group
+    -----
+    align
+    """
+
     def __init__(
         self,
         start: int = 0,
@@ -331,20 +394,12 @@ class StackRegAligner(AlignmentStrategy):
         ----------
         stack
             The image series to be aligned
-        start
-            Position in tilt series to use as starting point for the alignment.
-            If ``None``, the slice closest to the midpoint will be used.
-        show_progressbar
-            Enable/disable progress bar
 
         Returns
         -------
         shifts : :py:class:`~numpy.ndarray`
-            The X- and Y-shifts to be applied to each image
+            The shifts to be applied to each image
 
-        Group
-        -----
-        align
         """
         shifts = np.zeros((stack.data.shape[0], 2))
 
@@ -378,6 +433,32 @@ class StackRegAligner(AlignmentStrategy):
 
 
 class CoMAligner(AlignmentStrategy):
+    """
+    Center of mass (COM) tracking alignment strategy.
+
+    A Python implementation of algorithms described in:
+    T. Sanders. Physically motivated global alignment method for electron
+    tomography, Advanced Structural and Chemical Imaging vol. 1 (2015) pp 1-11.
+    https://doi.org/10.1186/s40679-015-0005-7
+
+    Attributes
+    ----------
+    start
+        Position in tilt series to use as starting point for the alignment.
+        If ``None``, the slice closest to the midpoint will be used.
+    show_progressbar
+        Enable/disable progress bar
+
+    Returns
+    -------
+    shifts : :py:class:`~numpy.ndarray`
+        The X- and Y-shifts to be applied to each image
+
+    Group
+    -----
+    align
+    """
+
     def __init__(
         self,
         start: int = 0,
@@ -394,6 +475,7 @@ class CoMAligner(AlignmentStrategy):
         self.nslices = nslices
 
     def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
+        """Calculate shifts using center of mass tracking method."""
         logger.info("Performing stack registration using center of mass method")
         shifts = np.zeros([stack.data.shape[0], 2])
         # _calculate_shifts_conservation_of_mass: x-shifts (parallel to tilt axis)
@@ -512,6 +594,36 @@ class CoMAligner(AlignmentStrategy):
 
 
 class CommonLineAligner(AlignmentStrategy):
+    """
+    Aligner class for common line (CL) strategy.
+
+    A combination of center of mass tracking for aligment of projections perpendicular
+    to the tilt axis and common line alignment for parallel to the tilt axis. This is a
+    Python implementation of Matlab code described in:
+    M. C. Scott, et al. Electron tomography at 2.4-ångström resolution,
+    Nature 483, 444-447 (2012).
+    https://doi.org/10.1038/nature10934
+
+    Attributes
+    ----------
+    start : py:class:`~int`
+        Position in tilt series to use as starting point for the alignment. If ``None``,
+        the slice closest to the midpoint will be used.
+    com_ref_index : py:class:`~int`
+        Reference slice for center of mass alignment.  All other slices
+        will be aligned to this reference.
+    cl_ref_index : py:class:`~int`
+        Reference slice for common line alignment.  All other slices
+        will be aligned to this reference. If not provided the projection
+        closest to the middle of the stack will be chosen.
+    cl_resolution : py:class:`~float`
+        Resolution for subpixel common line alignment. Default is 0.05.
+        Should be less than 0.5.
+    cl_div_factor : py:class:`~int`
+        Factor which determines the number of iterations of common line
+        alignment to perform.  Default is 8.
+    """
+
     def __init__(
         self,
         start: int = 0,
@@ -521,15 +633,15 @@ class CommonLineAligner(AlignmentStrategy):
         cl_resolution: float = 0.05,
         cl_div_factor: int = 8,
     ):
-        super().__init__(use_cuda=False)
+        super().__init__(use_cuda=False, show_progressbar=show_progressbar)
         self.start = start
-        self.show_progressbar = show_progressbar
         self.com_ref_index = com_ref_index
         self.cl_ref_index = cl_ref_index
         self.cl_resolution = cl_resolution
         self.cl_div_factor = cl_div_factor
 
     def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
+        """Calculate shifts using combined center of mass and common line methods."""
         logger.info(
             "Performing stack registration using combined "
             "center of mass and common line methods",
@@ -555,31 +667,15 @@ class CommonLineAligner(AlignmentStrategy):
         """
         Calculate shifts using combined center of mass and common line methods.
 
-        Center of mass aligns stack perpendicular to the tilt axis and
-        common line is used to align the stack parallel to the tilt axis.
-
         Parameters
         ----------
-        stack
+        stack : :py:class:`~TomoStack`
             Tilt series to be aligned
-        com_ref_index
-            Reference slice for center of mass alignment.  All other slices
-            will be aligned to this reference.
-        cl_ref_index
-            Reference slice for common line alignment.  All other slices
-            will be aligned to this reference. If not provided the projection
-            closest to the middle of the stack will be chosen.
-        cl_resolution
-            Resolution for subpixel common line alignment. Default is 0.05.
-            Should be less than 0.5.
-        cl_div_factor
-            Factor which determines the number of iterations of common line
-            alignment to perform.  Default is 8.
 
         Returns
         -------
-        reg : :py:class:`~numpy.ndarray`
-            The X- and Y-shifts to be applied to each image
+        shifts : :py:class:`~numpy.ndarray`
+            The calculated shifts to be applied to each image
 
         Group
         -----
@@ -686,20 +782,30 @@ def apply_shifts(
     """
     Apply a series of shifts to a TomoStack.
 
+    Shifts are applied to the data using either interpolation or Fourier shift methods.
+    These operations are carried out using either CPU or GPU resources depending on the
+    value of `cuda`. If `cuda` is True, the shifts will be applied using
+    GPU-acceleration via CuPy. The shifts are stored in
+    ``shifted.metadata.Tomography.shifts``.
+
     Parameters
     ----------
-    stack
+    stack : :py:class:`~TomoStack`
         The image series to be aligned
-    shifts
+    shifts : Union[:py:class:`~TomoShifts`, :py:class:`~numpy.ndarray`]
         The X- (tilt parallel) and Y-shifts (tilt perpendicular) to be applied to
         each image. Should be of size
         ``(*stack.axes_manager.navigation_shape[::-1], 2)``,
         with Y-shifts in the ``shifts[:, 0]`` position and X-shifts in ``shifts[:, 1]``
         position (if ``shifts`` is a :py:class:`~numpy.ndarray`).
-    method
+    method : :py:class:`~str`
         Image shifts can be applied using either interpolation via scipy.ndimage.shift
         or via Fourier shift as implemented in scipy.ndimage.fourier_shift.  Must be
         either 'interp' or 'fourier'.
+    cuda : :py:class:`~bool`
+        Enable/disable the use of GPU-accelerated processes using CUDA. If True, shifts
+        will be applied using CuPy. If False, shifts will be applied using NumPy and
+        SciPy.
 
     Returns
     -------

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -251,6 +251,70 @@ class PhaseCorrelationAligner(AlignmentStrategy):
         return data
 
 
+class StackRegAligner(AlignmentStrategy):
+    def __init__(
+        self,
+        start: int = 0,
+        show_progressbar: bool = True,
+    ):
+        super().__init__(use_cuda=False)
+        self.start = start
+        self.show_progressbar = show_progressbar
+
+    def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
+        """
+        Calculate shifts using PyStackReg.
+
+        Parameters
+        ----------
+        stack
+            The image series to be aligned
+        start
+            Position in tilt series to use as starting point for the alignment.
+            If ``None``, the slice closest to the midpoint will be used.
+        show_progressbar
+            Enable/disable progress bar
+
+        Returns
+        -------
+        shifts : :py:class:`~numpy.ndarray`
+            The X- and Y-shifts to be applied to each image
+
+        Group
+        -----
+        align
+        """
+        shifts = np.zeros((stack.data.shape[0], 2))
+
+        if self.start is None:
+            self.start = (
+                stack.data.shape[0] // 2
+            )  # Use the midpoint if start is not provided
+        self.start = cast("int", self.start)
+
+        # Initialize pystackreg object with TranslationTransform2D
+        reg = StackReg(StackReg.TRANSLATION)
+
+        with tqdm.tqdm(
+            total=stack.data.shape[0] - 1,
+            desc="Calculating shifts",
+            disable=not self.show_progressbar,
+        ) as pbar:
+            # Calculate shifts relative to the image at the 'start' index
+            for i in range(self.start, 0, -1):
+                transformation = reg.register(stack.data[i], stack.data[i - 1])
+                shift = -transformation[0:2, 2][::-1]
+                shifts[i - 1] = shifts[i] + shift
+                pbar.update(1)
+
+            for i in range(self.start, stack.data.shape[0] - 1):
+                transformation = reg.register(stack.data[i], stack.data[i + 1])
+                shift = -transformation[0:2, 2][::-1]
+                shifts[i + 1] = shifts[i] + shift
+                pbar.update(1)
+        return shifts
+
+
 def get_best_slices(stack: "TomoStack", nslices: int) -> np.ndarray:
     """
     Get best nslices for center of mass analysis.
@@ -649,62 +713,6 @@ def calculate_shifts_com(stack: "TomoStack", nslices: int) -> np.ndarray:
     return yshifts
 
 
-def calculate_shifts_stackreg(
-    stack: "TomoStack",
-    start: int | None,
-    show_progressbar: bool,
-) -> np.ndarray:
-    """
-    Calculate shifts using PyStackReg.
-
-    Parameters
-    ----------
-    stack
-        The image series to be aligned
-    start
-        Position in tilt series to use as starting point for the alignment. If ``None``,
-        the slice closest to the midpoint will be used.
-    show_progressbar
-        Enable/disable progress bar
-
-    Returns
-    -------
-    shifts : :py:class:`~numpy.ndarray`
-        The X- and Y-shifts to be applied to each image
-
-    Group
-    -----
-    align
-    """
-    shifts = np.zeros((stack.data.shape[0], 2))
-
-    if start is None:
-        start = stack.data.shape[0] // 2  # Use the midpoint if start is not provided
-    start = cast("int", start)
-
-    # Initialize pystackreg object with TranslationTransform2D
-    reg = StackReg(StackReg.TRANSLATION)
-
-    with tqdm.tqdm(
-        total=stack.data.shape[0] - 1,
-        desc="Calculating shifts",
-        disable=not show_progressbar,
-    ) as pbar:
-        # Calculate shifts relative to the image at the 'start' index
-        for i in range(start, 0, -1):
-            transformation = reg.register(stack.data[i], stack.data[i - 1])
-            shift = -transformation[0:2, 2][::-1]
-            shifts[i - 1] = shifts[i] + shift
-            pbar.update(1)
-
-        for i in range(start, stack.data.shape[0] - 1):
-            transformation = reg.register(stack.data[i], stack.data[i + 1])
-            shift = -transformation[0:2, 2][::-1]
-            shifts[i + 1] = shifts[i] + shift
-            pbar.update(1)
-    return shifts
-
-
 def calc_shifts_com_cl(
     stack: "TomoStack",
     com_ref_index: int,
@@ -776,7 +784,6 @@ def align_stack(  # noqa: PLR0913
     stack: "TomoStack",
     method: AlignmentMethodType,
     start: int | None,
-    show_progressbar: bool,
     xrange: tuple[int, int] | None = None,
     shift_type: Literal["fourier", "interp"] = "fourier",
     p: int = 20,
@@ -901,9 +908,6 @@ def align_stack(  # noqa: PLR0913
         # calculate_shifts_com returns y-shifts (perpendicular to tilt axis)
         shifts[:, 1] = calculate_shifts_conservation_of_mass(stack, xrange, p)
         shifts[:, 0] = calculate_shifts_com(stack, nslices)
-    elif method == AlignmentMethod.STACK_REG:
-        logger.info("Performing stack registration using PyStackReg")
-        shifts = calculate_shifts_stackreg(stack, start, show_progressbar)
     elif method == AlignmentMethod.COM_CL:
         logger.info(
             "Performing stack registration using combined "

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -39,7 +39,7 @@ logger.setLevel(logging.INFO)
 CL_RES_THRESHOLD = 0.5  # threshold for common line registration method
 
 
-class AlignmentMethod(ABC):
+class AlignmentStrategy(ABC):
     """Abstract Base class for Alignment methods."""
 
     @abstractmethod
@@ -63,7 +63,7 @@ class StackAligner:
 
     def align(
         self,
-        align_method: AlignmentMethod,
+        align_method: AlignmentStrategy,
         shift_method: str = "fourier",
     ) -> "TomoStack":
         """Align stack using the specified strategy and method for applying shifts."""
@@ -76,7 +76,7 @@ class StackAligner:
         return apply_shifts(self.stack, self.shifts, shift_method)
 
 
-class PhaseCorrelationAligner(AlignmentMethod):
+class PhaseCorrelationAligner(AlignmentStrategy):
     """Phase correlation alignment strategy."""
 
     def __init__(

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -315,6 +315,137 @@ class StackRegAligner(AlignmentStrategy):
         return shifts
 
 
+class CoMAligner(AlignmentStrategy):
+    def __init__(
+        self,
+        start: int = 0,
+        show_progressbar: bool = True,
+        xrange: tuple[int, int] | None = None,
+        p: int = 20,
+        nslices: int = 20,
+    ):
+        super().__init__(use_cuda=False)
+        self.start = start
+        self.show_progressbar = show_progressbar
+        self.xrange = xrange
+        self.p = p
+        self.nslices = nslices
+
+    def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
+        logger.info("Performing stack registration using center of mass method")
+        shifts = np.zeros([stack.data.shape[0], 2])
+        # calculate_shifts_conservation_of_mass returns x-shifts (parallel to tilt axis)
+        # calculate_shifts_com returns y-shifts (perpendicular to tilt axis)
+        shifts[:, 1] = self._calculate_shifts_conservation_of_mass(
+            stack,
+            self.xrange,
+            self.p,
+        )
+        shifts[:, 0] = self._calculate_shifts_com(stack, self.nslices)
+        return shifts
+
+    def _calculate_shifts_conservation_of_mass(
+        self,
+        stack: "TomoStack",
+        xrange: tuple[int, int] | None = None,
+        p: int = 20,
+    ) -> np.ndarray:
+        """
+        Calculate shifts parallel to the tilt axis using conservation of mass.
+
+        Slices which have the highest ratio of total mass to mass variance
+        and their location are returned.
+
+        Parameters
+        ----------
+        stack
+            Tilt series to be aligned.
+        xrange
+            The range for performing alignment
+        p
+            Padding element
+
+        Returns
+        -------
+        xshifts : :py:class:`~numpy.ndarray`
+            Calculated shifts parallel to tilt axis.
+
+        Group
+        -----
+        align
+        """
+        logger.info("Refinining X-shifts using conservation of mass method")
+        ntilts, _, nx = stack.data.shape
+
+        if xrange is None:
+            xrange = (round(nx / 5), round(4 / 5 * nx))
+        else:
+            xrange = (round(xrange[0]) + p, round(xrange[1]) - p)
+
+        xshifts = np.zeros([ntilts, 1])
+        total_mass = np.zeros([ntilts, xrange[1] - xrange[0] + 2 * p + 1])
+
+        for i in range(ntilts):
+            total_mass[i, :] = np.sum(
+                stack.data[i, :, xrange[0] - p - 1 : xrange[1] + p],
+                0,
+            )
+
+        mean_mass = np.mean(total_mass[:, p:-p], 0)
+
+        for i in range(ntilts):
+            s = 0
+            for j in range(-p, p):
+                resid = np.linalg.norm(mean_mass - total_mass[i, p + j : -p + j])
+                if resid < s or j == -p:
+                    s = resid
+                    xshifts[i] = -j
+        return xshifts[:, 0]
+
+    def _calculate_shifts_com(self, stack: "TomoStack", nslices: int) -> np.ndarray:
+        """
+        Align stack using a center of mass method.
+
+        Data is first registered using PyStackReg. Then, the shifts
+        perpendicular to the tilt axis are refined by a center of
+        mass analysis.
+
+        Parameters
+        ----------
+        stack
+            The image series to be aligned
+
+        nslices
+            Number of slices to return
+
+        Returns
+        -------
+        shifts : :py:class:`~numpy.ndarray`
+            The X- and Y-shifts to be applied to each image
+
+        Group
+        -----
+        align
+        """
+        logger.info("Refinining Y-shifts using center of mass method")
+        slices = get_best_slices(stack, nslices)
+
+        angles = stack.tilts.data.squeeze()
+        ntilts, _, _ = stack.data.shape
+        thetas = np.pi * cast("np.ndarray", angles) / 180
+
+        coms = get_coms(stack, slices)
+        i_tilts = np.eye(ntilts)
+        gam = np.array([np.cos(thetas), np.sin(thetas)]).T
+        gam = np.dot(gam, np.linalg.pinv(gam)) - i_tilts
+        b = np.dot(gam, coms)
+
+        cx = np.linalg.lstsq(gam, b, rcond=-1)[0]
+
+        yshifts = -cx[:, 0]
+        return yshifts
+
+
 def get_best_slices(stack: "TomoStack", nslices: int) -> np.ndarray:
     """
     Get best nslices for center of mass analysis.

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -112,12 +112,7 @@ class PhaseCorrelationAligner(AlignmentStrategy):
         align
         """
         if has_cupy and astra.use_cuda() and self.use_cuda:
-            shifts = _cupy_calculate_shifts(
-                stack,
-                self.start,
-                self.show_progressbar,
-                self.upsample_factor,
-            )
+            shifts = self._cupy_calculate_shifts(stack)
 
         else:
             shifts = np.zeros((stack.data.shape[0], 2))
@@ -144,6 +139,116 @@ class PhaseCorrelationAligner(AlignmentStrategy):
                     shifts[i + 1] = shifts[i] + shift
                     pbar.update(1)
         return shifts
+
+    def _cupy_calculate_shifts(self, stack):
+        stack_cp = cp.array(stack.data)
+        shifts = cp.zeros([stack_cp.shape[0], 2])
+        ref_cp = stack_cp[0]
+        ref_fft = cp.fft.fftn(ref_cp)
+        shape = ref_fft.shape
+        with tqdm.tqdm(
+            total=stack.data.shape[0] - 1,
+            desc="Calculating shifts",
+            disable=not self.show_progressbar,
+        ) as pbar:
+            for i in range(self.start, 0, -1):
+                shift = self._cupy_phase_correlate(
+                    stack_cp[i],
+                    stack_cp[i - 1],
+                    shape=shape,
+                )
+                shifts[i - 1] = shifts[i] + shift
+                pbar.update(1)
+            for i in range(self.start, stack.data.shape[0] - 1):
+                shift = self._cupy_phase_correlate(
+                    stack_cp[i],
+                    stack_cp[i + 1],
+                    shape=shape,
+                )
+                shifts[i + 1] = shifts[i] + shift
+                pbar.update(1)
+        shifts = shifts.get()
+        return shifts
+
+    def _cupy_phase_correlate(self, ref_cp, mov_cp, shape):
+        # missing coverage b/c of CUDA
+        ref_fft = cp.fft.fftn(ref_cp)
+        mov_fft = cp.fft.fftn(mov_cp)
+
+        cross_power_spectrum = ref_fft * mov_fft.conj()
+        eps = cp.finfo(cross_power_spectrum.real.dtype).eps
+        cross_power_spectrum /= cp.maximum(cp.abs(cross_power_spectrum), 100 * eps)
+        phase_correlation = cp.fft.ifft2(cross_power_spectrum)
+
+        maxima = cp.unravel_index(
+            cp.argmax(cp.abs(phase_correlation)),
+            phase_correlation.shape,
+        )
+        midpoint = cp.array([cp.fix(axis_size / 2) for axis_size in shape])
+
+        float_dtype = cross_power_spectrum.real.dtype
+
+        shift = cp.stack(maxima).astype(float_dtype, copy=False)
+        shift[shift > midpoint] -= cp.array(shape)[shift > midpoint]
+
+        if self.upsample_factor > 1:
+            upsample_factor = cp.array(self.upsample_factor, dtype=float_dtype)
+            upsampled_region_size = cp.ceil(upsample_factor * 1.5)
+            dftshift = cp.fix(upsampled_region_size / 2.0)
+
+            shift = cp.round(shift * upsample_factor) / upsample_factor
+
+            sample_region_offset = dftshift - shift * upsample_factor
+            phase_correlation = self._upsampled_dft(
+                cross_power_spectrum.conj(),
+                upsampled_region_size,
+                upsample_factor,
+                sample_region_offset,
+            ).conj()
+            maxima = np.unravel_index(
+                cp.argmax(np.abs(phase_correlation)),
+                phase_correlation.shape,
+            )
+
+            maxima = cp.stack(maxima).astype(float_dtype, copy=False)
+            maxima -= dftshift
+
+            shift += maxima / upsample_factor
+        return shift
+
+    def _upsampled_dft(
+        self,
+        data,
+        upsampled_region_size,
+        upsample_factor,
+        axis_offsets,
+    ):
+        # missing coverage because of CUDA
+        upsampled_region_size = [
+            upsampled_region_size,
+        ] * data.ndim
+
+        im2pi = 1j * 2 * cp.pi
+
+        dim_properties = list(
+            zip(
+                data.shape,
+                upsampled_region_size,
+                axis_offsets,
+                strict=False,
+            ),
+        )
+
+        for n_items, ups_size, ax_offset in dim_properties[::-1]:
+            kernel = (cp.arange(ups_size) - ax_offset)[:, None] * cp.fft.fftfreq(
+                n_items,
+                upsample_factor,
+            )
+            kernel = cp.exp(-im2pi * kernel)
+            # use kernel with same precision as the data
+            kernel = kernel.astype(data.dtype, copy=False)
+            data = cp.tensordot(kernel, data, axes=(1, -1))  # type: ignore
+        return data
 
 
 def get_best_slices(stack: "TomoStack", nslices: int) -> np.ndarray:
@@ -542,120 +647,6 @@ def calculate_shifts_com(stack: "TomoStack", nslices: int) -> np.ndarray:
 
     yshifts = -cx[:, 0]
     return yshifts
-
-
-def _upsampled_dft(
-    data,
-    upsampled_region_size,
-    upsample_factor,
-    axis_offsets,
-):
-    # missing coverage because of CUDA
-    upsampled_region_size = [
-        upsampled_region_size,
-    ] * data.ndim
-
-    im2pi = 1j * 2 * cp.pi
-
-    dim_properties = list(
-        zip(
-            data.shape,
-            upsampled_region_size,
-            axis_offsets,
-            strict=False,
-        ),
-    )
-
-    for n_items, ups_size, ax_offset in dim_properties[::-1]:
-        kernel = (cp.arange(ups_size) - ax_offset)[:, None] * cp.fft.fftfreq(
-            n_items,
-            upsample_factor,
-        )
-        kernel = cp.exp(-im2pi * kernel)
-        # use kernel with same precision as the data
-        kernel = kernel.astype(data.dtype, copy=False)
-        data = cp.tensordot(kernel, data, axes=(1, -1))  # type: ignore
-    return data
-
-
-def _cupy_phase_correlate(ref_cp, mov_cp, upsample_factor, shape):
-    # missing coverage b/c of CUDA
-    ref_fft = cp.fft.fftn(ref_cp)
-    mov_fft = cp.fft.fftn(mov_cp)
-
-    cross_power_spectrum = ref_fft * mov_fft.conj()
-    eps = cp.finfo(cross_power_spectrum.real.dtype).eps
-    cross_power_spectrum /= cp.maximum(cp.abs(cross_power_spectrum), 100 * eps)
-    phase_correlation = cp.fft.ifft2(cross_power_spectrum)
-
-    maxima = cp.unravel_index(
-        cp.argmax(cp.abs(phase_correlation)),
-        phase_correlation.shape,
-    )
-    midpoint = cp.array([cp.fix(axis_size / 2) for axis_size in shape])
-
-    float_dtype = cross_power_spectrum.real.dtype
-
-    shift = cp.stack(maxima).astype(float_dtype, copy=False)
-    shift[shift > midpoint] -= cp.array(shape)[shift > midpoint]
-
-    if upsample_factor > 1:
-        upsample_factor = cp.array(upsample_factor, dtype=float_dtype)
-        upsampled_region_size = cp.ceil(upsample_factor * 1.5)
-        dftshift = cp.fix(upsampled_region_size / 2.0)
-
-        shift = cp.round(shift * upsample_factor) / upsample_factor
-
-        sample_region_offset = dftshift - shift * upsample_factor
-        phase_correlation = _upsampled_dft(
-            cross_power_spectrum.conj(),
-            upsampled_region_size,
-            upsample_factor,
-            sample_region_offset,
-        ).conj()
-        maxima = np.unravel_index(
-            cp.argmax(np.abs(phase_correlation)),
-            phase_correlation.shape,
-        )
-
-        maxima = cp.stack(maxima).astype(float_dtype, copy=False)
-        maxima -= dftshift
-
-        shift += maxima / upsample_factor
-    return shift
-
-
-def _cupy_calculate_shifts(stack, start, show_progressbar, upsample_factor):
-    stack_cp = cp.array(stack.data)
-    shifts = cp.zeros([stack_cp.shape[0], 2])
-    ref_cp = stack_cp[0]
-    ref_fft = cp.fft.fftn(ref_cp)
-    shape = ref_fft.shape
-    with tqdm.tqdm(
-        total=stack.data.shape[0] - 1,
-        desc="Calculating shifts",
-        disable=not show_progressbar,
-    ) as pbar:
-        for i in range(start, 0, -1):
-            shift = _cupy_phase_correlate(
-                stack_cp[i],
-                stack_cp[i - 1],
-                upsample_factor=upsample_factor,
-                shape=shape,
-            )
-            shifts[i - 1] = shifts[i] + shift
-            pbar.update(1)
-        for i in range(start, stack.data.shape[0] - 1):
-            shift = _cupy_phase_correlate(
-                stack_cp[i],
-                stack_cp[i + 1],
-                upsample_factor=upsample_factor,
-                shape=shape,
-            )
-            shifts[i + 1] = shifts[i] + shift
-            pbar.update(1)
-    shifts = shifts.get()
-    return shifts
 
 
 def calculate_shifts_stackreg(

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -341,7 +341,7 @@ class CoMAligner(AlignmentStrategy):
             self.xrange,
             self.p,
         )
-        shifts[:, 0] = self._calculate_shifts_com(stack, self.nslices)
+        shifts[:, 0] = self._calculate_shifts_com(stack)
         return shifts
 
     def _calculate_shifts_conservation_of_mass(
@@ -402,7 +402,10 @@ class CoMAligner(AlignmentStrategy):
                     xshifts[i] = -j
         return xshifts[:, 0]
 
-    def _calculate_shifts_com(self, stack: "TomoStack", nslices: int) -> np.ndarray:
+    def _calculate_shifts_com(
+        self,
+        stack: "TomoStack",
+    ) -> np.ndarray:
         """
         Align stack using a center of mass method.
 
@@ -428,7 +431,7 @@ class CoMAligner(AlignmentStrategy):
         align
         """
         logger.info("Refinining Y-shifts using center of mass method")
-        slices = get_best_slices(stack, nslices)
+        slices = get_best_slices(stack, self.nslices)
 
         angles = stack.tilts.data.squeeze()
         ntilts, _, _ = stack.data.shape
@@ -444,6 +447,112 @@ class CoMAligner(AlignmentStrategy):
 
         yshifts = -cx[:, 0]
         return yshifts
+
+
+class CommonLineAligner(AlignmentStrategy):
+    def __init__(
+        self,
+        start: int = 0,
+        show_progressbar: bool = True,
+        com_ref_index: int | None = None,
+        cl_ref_index: int | None = None,
+        cl_resolution: float = 0.05,
+        cl_div_factor: int = 8,
+    ):
+        super().__init__(use_cuda=False)
+        self.start = start
+        self.show_progressbar = show_progressbar
+        self.com_ref_index = com_ref_index
+        self.cl_ref_index = cl_ref_index
+        self.cl_resolution = cl_resolution
+        self.cl_div_factor = cl_div_factor
+
+    def calculate_shifts(self, stack: "TomoStack") -> np.ndarray:
+        logger.info(
+            "Performing stack registration using combined "
+            "center of mass and common line methods",
+        )
+        if self.com_ref_index is None:
+            self.com_ref_index = stack.data.shape[1] // 2
+        if self.cl_ref_index is None:
+            self.cl_ref_index = stack.data.shape[0] // 2
+
+        # explicit type casts for type checking
+        self.com_ref_index = cast("int", self.com_ref_index)
+        self.cl_ref_index = cast("int", self.cl_ref_index)
+
+        shifts = self._calc_shifts_com_cl(
+            stack,
+        )
+        return shifts
+
+    def _calc_shifts_com_cl(
+        self,
+        stack: "TomoStack",
+    ) -> np.ndarray:
+        """
+        Calculate shifts using combined center of mass and common line methods.
+
+        Center of mass aligns stack perpendicular to the tilt axis and
+        common line is used to align the stack parallel to the tilt axis.
+
+        Parameters
+        ----------
+        stack
+            Tilt series to be aligned
+        com_ref_index
+            Reference slice for center of mass alignment.  All other slices
+            will be aligned to this reference.
+        cl_ref_index
+            Reference slice for common line alignment.  All other slices
+            will be aligned to this reference. If not provided the projection
+            closest to the middle of the stack will be chosen.
+        cl_resolution
+            Resolution for subpixel common line alignment. Default is 0.05.
+            Should be less than 0.5.
+        cl_div_factor
+            Factor which determines the number of iterations of common line
+            alignment to perform.  Default is 8.
+
+        Returns
+        -------
+        reg : :py:class:`~numpy.ndarray`
+            The X- and Y-shifts to be applied to each image
+
+        Group
+        -----
+        align
+        """
+
+        def calc_yshifts(stack, com_ref):
+            ntilts = stack.data.shape[0]
+            ali_x = stack.deepcopy()
+            coms = np.zeros(ntilts)
+            yshifts = np.zeros_like(coms)
+
+            for i in tqdm.tqdm(range(ntilts)):
+                im = ali_x.data[i, :, :]
+                coms[i], _ = ndimage.center_of_mass(im)
+                yshifts[i] = com_ref - coms[i]
+            return yshifts
+
+        if self.cl_resolution >= CL_RES_THRESHOLD:
+            msg = f"Resolution should be less than {CL_RES_THRESHOLD}"
+            raise ValueError(msg)
+
+        logger.info("Center of mass reference slice: %s", self.com_ref_index)
+        logger.info("Common line reference slice: %s", self.cl_ref_index)
+        xshifts = np.zeros(stack.data.shape[0])
+        yshifts = np.zeros(stack.data.shape[0])
+        yshifts = calc_yshifts(stack, self.com_ref_index)
+        xshifts = calc_shifts_cl(
+            stack,
+            self.cl_ref_index,
+            self.cl_resolution,
+            self.cl_div_factor,
+        )
+        shifts = np.stack([yshifts, xshifts], axis=1)
+        return shifts
 
 
 def get_best_slices(stack: "TomoStack", nslices: int) -> np.ndarray:
@@ -911,14 +1020,11 @@ def calc_shifts_com_cl(
     return shifts
 
 
-def align_stack(  # noqa: PLR0913
+def align_stack(
     stack: "TomoStack",
     method: AlignmentMethodType,
     start: int | None,
-    xrange: tuple[int, int] | None = None,
     shift_type: Literal["fourier", "interp"] = "fourier",
-    p: int = 20,
-    nslices: int = 20,
     cuda: bool = False,
     com_ref_index: int | None = None,
     cl_ref_index: int | None = None,
@@ -1032,14 +1138,7 @@ def align_stack(  # noqa: PLR0913
         )  # Use the slice closest to the midpoint if start is not provided
     start = cast("int", start)  # explicit type cast for type checking
 
-    if method == AlignmentMethod.COM:
-        logger.info("Performing stack registration using center of mass method")
-        shifts = np.zeros([stack.data.shape[0], 2])
-        # calculate_shifts_conservation_of_mass returns x-shifts (parallel to tilt axis)
-        # calculate_shifts_com returns y-shifts (perpendicular to tilt axis)
-        shifts[:, 1] = calculate_shifts_conservation_of_mass(stack, xrange, p)
-        shifts[:, 0] = calculate_shifts_com(stack, nslices)
-    elif method == AlignmentMethod.COM_CL:
+    if method == AlignmentMethod.COM_CL:
         logger.info(
             "Performing stack registration using combined "
             "center of mass and common line methods",

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -6,7 +6,6 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Literal, Union, cast
 
-import astra
 import matplotlib.pylab as plt
 import numpy as np
 import tqdm
@@ -345,7 +344,7 @@ class PhaseCorrelationAligner(StackAligner):
         -----
         align
         """
-        if has_cupy and astra.use_cuda() and self.use_cuda:
+        if has_cupy and self.use_cuda:
             shifts = self._cupy_calculate_shifts()
 
         else:

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -68,7 +68,7 @@ class StackAligner:
     ) -> "TomoStack":
         """Align stack using the specified strategy and method for applying shifts."""
         # 1. Calculate
-        self.shifts = align_method.calculate(self.stack)
+        self.shifts = align_method.calculate_shifts(self.stack)
 
         # 2. Apply (Determine if CUDA is needed automatically)
         if hasattr(align_method, "cuda") and align_method.cuda and has_cupy:
@@ -216,6 +216,7 @@ def apply_shifts(
     shifts: Union["TomoShifts", np.ndarray],
     method: Literal["interp", "fourier"] = "fourier",
     cuda: bool = False,
+    **kwargs,
 ) -> "TomoStack":
     """
     Apply a series of shifts to a TomoStack.
@@ -261,21 +262,23 @@ def apply_shifts(
 
     data = xp.array(shifted.data)
     if method.lower() == "interp":
+        order = kwargs.pop("order", 3)
         shift_func = shift_gpu if cuda else ndimage.shift
         for i in range(data.shape[0]):
             data[i, :, :] = shift_func(
                 data[i, :, :],
                 shift=[shifts[i, 0], shifts[i, 1]],
+                order=order,
             )
     elif method.lower() == "fourier":
         fourier_shift_func = fourier_shift_gpu if cuda else ndimage.fourier_shift
         _, ny, nx = data.shape
-        y_pad_min = xp.abs(shifts[:, 0]).max() + ny
-        ny_pad = int(2 ** xp.ceil(np.log2(y_pad_min)))
+        y_pad_min = np.abs(shifts[:, 0]).max() + ny
+        ny_pad = int(2 ** np.ceil(np.log2(y_pad_min)))
         y_pad_width = [(ny_pad - ny) // 2, (ny_pad - ny + 1) // 2]
 
-        x_pad_min = xp.abs(shifts[:, 1]).max() + nx
-        nx_pad = int(2 ** xp.ceil(np.log2(x_pad_min)))
+        x_pad_min = np.abs(shifts[:, 1]).max() + nx
+        nx_pad = int(2 ** np.ceil(np.log2(x_pad_min)))
         x_pad_width = [(nx_pad - nx) // 2, (nx_pad - nx + 1) // 2]
 
         data = xp.pad(
@@ -285,7 +288,7 @@ def apply_shifts(
         )
 
         _, ny, nx = data.shape
-        data_fft = fft_module.fft2(shifted.data, axes=(1, 2))
+        data_fft = fft_module.fft2(data, axes=(1, 2))
         for i in range(data.shape[0]):
             data_fft[i, :, :] = fft_module.ifft2(
                 fourier_shift_func(
@@ -306,7 +309,7 @@ def apply_shifts(
         raise ValueError(msg)
 
     shifted.data = cp.asnumpy(data) if cuda else data
-    shifted.shifts.data = shifted.shifts.data + (cp.asnumpy(shifts) if cuda else shifts)
+    shifted.shifts.data = shifted.shifts.data + shifts
     return shifted
 
 

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -72,7 +72,7 @@ class StackAligner:
 
         # 2. Apply (Determine if CUDA is needed automatically)
         if hasattr(align_method, "cuda") and align_method.cuda and has_cupy:
-            return apply_shifts_cuda(self.stack, self.shifts, shift_method)
+            return apply_shifts(self.stack, self.shifts, shift_method, cuda=True)
         return apply_shifts(self.stack, self.shifts, shift_method)
 
 
@@ -215,6 +215,7 @@ def apply_shifts(
     stack: "TomoStack",
     shifts: Union["TomoShifts", np.ndarray],
     method: Literal["interp", "fourier"] = "fourier",
+    cuda: bool = False,
 ) -> "TomoStack":
     """
     Apply a series of shifts to a TomoStack.
@@ -244,6 +245,9 @@ def apply_shifts(
     align
     """
     shifted = stack.deepcopy()
+    xp = cp if cuda else np
+    fft_module = cp.fft if cuda else fft
+
     if isinstance(shifts, BaseSignal):
         shifts = shifts.data
     shifts = cast("np.ndarray", shifts)
@@ -255,134 +259,41 @@ def apply_shifts(
         )
         raise ValueError(msg)
 
+    data = xp.array(shifted.data)
     if method.lower() == "interp":
-        for i in range(shifted.data.shape[0]):
-            shifted.data[i, :, :] = ndimage.shift(
-                shifted.data[i, :, :],
-                shift=[shifts[i, 0], shifts[i, 1]],
-            )
-    elif method.lower() == "fourier":
-        _, ny, nx = shifted.data.shape
-        y_pad_min = np.abs(shifts[:, 0]).max() + ny
-        ny_pad = int(2 ** np.ceil(np.log2(y_pad_min)))
-        y_pad_width = [(ny_pad - ny) // 2, (ny_pad - ny + 1) // 2]
-
-        x_pad_min = np.abs(shifts[:, 1]).max() + nx
-        nx_pad = int(2 ** np.ceil(np.log2(x_pad_min)))
-        x_pad_width = [(nx_pad - nx) // 2, (nx_pad - nx + 1) // 2]
-
-        shifted_padded = np.pad(
-            shifted.data,
-            ((0, 0), y_pad_width, x_pad_width),
-            mode="constant",
-        )
-        shifted.data = shifted_padded
-        _, ny, nx = shifted.data.shape
-        shifted_fft = fft.fft2(shifted.data, axes=(1, 2))
-        for i in range(shifted.data.shape[0]):
-            shifted.data[i, :, :] = np.real(
-                np.asarray(
-                    fft.ifft2(
-                        ndimage.fourier_shift(
-                            shifted_fft[i],
-                            shift=[shifts[i, 0], shifts[i, 1]],
-                        ),
-                    ),
-                ),
-            )
-        slices = [
-            slice(0, None),
-        ]
-        for i in [y_pad_width, x_pad_width]:
-            i[1] = None if i[1] == 0 else -i[1]
-            slices.append(slice(i[0], i[1]))
-        shifted.data = shifted.data[tuple(slices)]
-    else:
-        msg = f"Invalid shift application method {method}."
-        raise ValueError(msg)
-
-    shifted.shifts.data = shifted.shifts.data + shifts
-    return shifted
-
-
-def apply_shifts_cuda(
-    stack: "TomoStack",
-    shifts: Union["TomoShifts", np.ndarray],
-    method: Literal["interp", "fourier"] = "fourier",
-) -> "TomoStack":
-    """
-    Apply a series of shifts to a TomoStack using CUDA acceleration.
-
-    Parameters
-    ----------
-    stack
-        The image series to be aligned
-    shifts
-        The X- (tilt parallel) and Y-shifts (tilt perpendicular) to be applied to
-        each image. Should be of size
-        ``(*stack.axes_manager.navigation_shape[::-1], 2)``,
-        with Y-shifts in the ``shifts[:, 0]`` position and X-shifts in ``shifts[:, 1]``
-        position (if ``shifts`` is a :py:class:`~numpy.ndarray`).
-    method
-        Image shifts can be applied using either interpolation via scipy.ndimage.shift
-        or via Fourier shift as implemented in scipy.ndimage.fourier_shift.  Must be
-        either 'interp' or 'fourier'.
-
-    Returns
-    -------
-    shifted : TomoStack
-        Copy of input stack after shifts are applied
-
-    Group
-    -----
-    align
-    """
-    shifted = stack.deepcopy()
-
-    data = cp.array(shifted.data)
-    if isinstance(shifts, BaseSignal):
-        shifts = shifts.data
-    shifts = cp.array(shifts)
-
-    if len(shifts) != stack.data.shape[0]:
-        msg = (
-            f"Number of shifts ({len(shifts)}) is not consistent "
-            f"with number of images in the stack ({stack.data.shape[0]})"
-        )
-        raise ValueError(msg)
-
-    if method.lower() == "interp":
+        shift_func = shift_gpu if cuda else ndimage.shift
         for i in range(data.shape[0]):
-            data[i, :, :] = shift_gpu(
+            data[i, :, :] = shift_func(
                 data[i, :, :],
                 shift=[shifts[i, 0], shifts[i, 1]],
             )
     elif method.lower() == "fourier":
+        fourier_shift_func = fourier_shift_gpu if cuda else ndimage.fourier_shift
         _, ny, nx = data.shape
-        y_pad_min = cp.abs(shifts[:, 0]).max() + ny
-        ny_pad = int(2 ** np.ceil(cp.log2(y_pad_min)))
+        y_pad_min = xp.abs(shifts[:, 0]).max() + ny
+        ny_pad = int(2 ** xp.ceil(np.log2(y_pad_min)))
         y_pad_width = [(ny_pad - ny) // 2, (ny_pad - ny + 1) // 2]
 
-        x_pad_min = cp.abs(shifts[:, 1]).max() + nx
-        nx_pad = int(2 ** cp.ceil(np.log2(x_pad_min)))
+        x_pad_min = xp.abs(shifts[:, 1]).max() + nx
+        nx_pad = int(2 ** xp.ceil(np.log2(x_pad_min)))
         x_pad_width = [(nx_pad - nx) // 2, (nx_pad - nx + 1) // 2]
 
-        padded = cp.pad(
+        data = xp.pad(
             data,
             ((0, 0), y_pad_width, x_pad_width),
             mode="constant",
         )
-        data = padded
+
         _, ny, nx = data.shape
-        data_fft = cp.fft.fft2(data, axes=(1, 2))
+        data_fft = fft_module.fft2(shifted.data, axes=(1, 2))
         for i in range(data.shape[0]):
-            data_fft[i, :, :] = cp.fft.ifft2(
-                fourier_shift_gpu(
+            data_fft[i, :, :] = fft_module.ifft2(
+                fourier_shift_func(
                     data_fft[i],
                     shift=[shifts[i, 0], shifts[i, 1]],
                 ),
             )
-        data = cp.real(data_fft)
+        data = xp.real(data_fft)
         slices = [
             slice(0, None),
         ]
@@ -394,8 +305,8 @@ def apply_shifts_cuda(
         msg = f"Invalid shift application method {method}."
         raise ValueError(msg)
 
-    shifted.data = cp.asnumpy(data)
-    shifted.shifts.data = shifted.shifts.data + cp.asnumpy(shifts)
+    shifted.data = cp.asnumpy(data) if cuda else data
+    shifted.shifts.data = shifted.shifts.data + (cp.asnumpy(shifts) if cuda else shifts)
     return shifted
 
 
@@ -1016,10 +927,7 @@ def align_stack(  # noqa: PLR0913
     else:
         msg = f"Invalid alignment method {method}"
         raise ValueError(msg)
-    if cuda:
-        aligned = apply_shifts_cuda(stack, shifts, shift_type)
-    else:
-        aligned = apply_shifts(stack, shifts, shift_type)
+    aligned = apply_shifts(stack, shifts, shift_type, cuda=cuda)
     logger.info("Stack registration complete")
     return aligned
 
@@ -1265,10 +1173,7 @@ def align_to_other(
     yshift = cast("float", stack_tomo_meta.yshift)
     out_tomo_meta.yshift = stack_tomo_meta.yshift
 
-    if cuda:
-        out = apply_shifts_cuda(out, stack.shifts, shift_type)
-    else:
-        out = apply_shifts(out, stack.shifts, shift_type)
+    out = apply_shifts(out, stack.shifts, shift_type, cuda=cuda)
 
     if stack_tomo_meta.cropped:
         out = shift_crop(out)

--- a/etspy/align.py
+++ b/etspy/align.py
@@ -313,7 +313,7 @@ class PhaseCorrelationAligner(StackAligner):
     def __init__(
         self,
         stack: "TomoStack",
-        start: int = 0,
+        start: int | None = 0,
         use_cuda: bool = False,
         show_progressbar: bool = True,
         **kwargs,
@@ -549,7 +549,7 @@ class StackRegAligner(StackAligner):
     def __init__(
         self,
         stack: "TomoStack",
-        start: int = 0,
+        start: int | None = 0,
         use_cuda: bool = False,
         show_progressbar: bool = True,
         **kwargs,
@@ -644,7 +644,7 @@ class CoMAligner(StackAligner):
     def __init__(
         self,
         stack: "TomoStack",
-        start: int = 0,
+        start: int | None = 0,
         use_cuda: bool = False,
         show_progressbar: bool = True,
         **kwargs,
@@ -809,7 +809,7 @@ class CommonLineAligner(StackAligner):
     def __init__(
         self,
         stack: "TomoStack",
-        start: int = 0,
+        start: int | None = 0,
         use_cuda: bool = False,
         show_progressbar: bool = True,
         **kwargs,

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -49,7 +49,7 @@ try:
 
     has_gpu = cp.cuda.runtime.getDeviceCount() > 0
 
-except (ImportError, ModuleNotFoundError):
+except Exception:
     has_cupy = False
     cp = None
     affine_transform_gpu = None

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -1325,16 +1325,10 @@ class TomoStack(CommonStack):
         method: AlignmentMethodType = AlignmentMethod.PC,
         start: int | None = None,
         show_progressbar: bool = False,
+        cuda: bool | None = False,
         crop: bool = False,
-        xrange: tuple[int, int] | None = None,
-        p: int = 20,
-        nslices: int = 20,
-        com_ref_index: int | None = None,
-        cl_ref_index: int | None = None,
-        cl_resolution: float = 0.05,
-        cl_div_factor: int = 8,
-        cuda: bool = False,
         shift_type: Literal["interp", "fourier"] = "fourier",
+        **kwargs,
     ) -> "TomoStack":
         """
         Register stack spatially.
@@ -1353,48 +1347,52 @@ class TomoStack(CommonStack):
             alignment. If ``None``, the central projection is used.
         show_progressbar
             Enable/disable progress bar
+        cuda
+            Whether or not to use CUDA-accelerated reconstruction algorithms.
         crop
             If True, crop aligned stack to eliminate border pixels. Default is
             False.
-        xrange
-            (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM`)
-            The range for performing alignment. See
-            :py:func:`~etspy.align.calculate_shifts_com` for more details.
-        p
-            (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM`)
-            Padding element. See :py:func:`~etspy.align.calculate_shifts_com` for more
-            details.
-        nslices
-            (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM`)
-            Number of slices to return. See
-            :py:func:`~etspy.align.calculate_shifts_com` for more details.
-        com_ref_index
-            (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
-            Reference slice for center of mass alignment.  All other slices
-            will be aligned to this reference.  If not provided, the midpoint
-            of the stack will be chosen. See :py:func:`~etspy.align.calc_shifts_com_cl`
-            for more details.
-        cl_ref_index
-            (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
-            Reference slice for common line alignment.  All other slices
-            will be aligned to this reference.  If not provided, the midpoint
-            of the stack will be chosen.
-        cl_resolution
-            (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
-            Resolution for subpixel common line alignment. Default is 0.05.
-            Should be less than 0.5. See
-            :py:func:`~etspy.align.calc_shifts_com_cl` for more details.
-        cl_div_factor
-            (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
-            Factor which determines the number of iterations of common line
-            alignment to perform.  Default is 8. See
-            :py:func:`~etspy.align.calc_shifts_com_cl` for more details.
-        cuda
-            Whether or not to use CUDA-accelerated reconstruction algorithms.
         shift_type
             Calculated image shifts can be applied using either interpolation via
             scipy.ndimage.shift or via Fourier shift as implemented in
             scipy.ndimage.fourier_shift.  Must be either 'interp' or 'fourier'.
+        **kwargs:
+            Remaining keyword arguments are passed to the underlying alignment functions.
+
+        Keyword arguments that may be used include:
+            xrange
+                (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM`)
+                The range for performing alignment. See
+                :py:func:`~etspy.align.calculate_shifts_com` for more details.
+            p
+                (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM`)
+                Padding element. See :py:func:`~etspy.align.calculate_shifts_com` for more
+                details.
+            nslices
+                (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM`)
+                Number of slices to return. See
+                :py:func:`~etspy.align.calculate_shifts_com` for more details.
+            com_ref_index
+                (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
+                Reference slice for center of mass alignment.  All other slices
+                will be aligned to this reference.  If not provided, the midpoint
+                of the stack will be chosen. See :py:func:`~etspy.align.calc_shifts_com_cl`
+                for more details.
+            cl_ref_index
+                (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
+                Reference slice for common line alignment.  All other slices
+                will be aligned to this reference.  If not provided, the midpoint
+                of the stack will be chosen.
+            cl_resolution
+                (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
+                Resolution for subpixel common line alignment. Default is 0.05.
+                Should be less than 0.5. See
+                :py:func:`~etspy.align.calc_shifts_com_cl` for more details.
+            cl_div_factor
+                (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
+                Factor which determines the number of iterations of common line
+                alignment to perform.  Default is 8. See
+                :py:func:`~etspy.align.calc_shifts_com_cl` for more details.
 
         Returns
         -------
@@ -1424,22 +1422,18 @@ class TomoStack(CommonStack):
             >>> regCOMCL = stack.stack_register('COM-CL')
 
         """
+        aligners = {
+            "PC": align.PhaseCorrelationAligner,
+            "StackReg": align.StackRegAligner,
+            "COM": align.CoMAligner,
+            "COM-CL": align.CommonLineAligner,
+        }
+
         if AlignmentMethod.is_valid_value(method):
-            out = align.align_stack(
-                self,
-                method,
-                start,
-                show_progressbar,
-                xrange=xrange,
-                p=p,
-                nslices=nslices,
-                com_ref_index=com_ref_index,
-                cl_ref_index=cl_ref_index,
-                cl_resolution=cl_resolution,
-                cl_div_factor=cl_div_factor,
-                cuda=cuda,
-                shift_type=shift_type,
+            aligner = aligners[method](
+                self, start, show_progressbar, cuda, crop, shift_type, **kwargs
             )
+            out = aligner.align()
         else:
             msg = (
                 f'Invalid registration method "{method}". '

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -1453,13 +1453,7 @@ class TomoStack(CommonStack):
     def tilt_align(
         self,
         method: Literal["CoM", "MaxImage"],
-        slices: np.ndarray | None = None,
-        nslices: int | None = None,
-        limit: float = 10,
-        delta: float = 0.1,
-        plot_results: bool = False,
-        also_shift: bool = False,
-        shift_limit: int = 20,
+        **kwargs,
     ):
         """
         Align the tilt axis of a TomoStack.
@@ -1487,38 +1481,44 @@ class TomoStack(CommonStack):
         method
             Algorithm to use for registration alignment. Must be either ``'CoM'`` or
             ``'MaxImage'``.
-        slices
-            (Only used when ``method == "CoM"``)
-            Locations at which to perform the Center of Mass analysis. If not
-            provided, an appropriate list of slices will be automatically determined.
-        nslices
-            (Only used when ``method == "CoM"``)
-            Nubmer of slices to use for the center of mass analysis (only used if the
-            ``slices`` parameter is not specified). If ``None``, a value of 10% of the
-            x-axis size will be used, clamped to the range [3, 50], as calculated in
-            the :py:func:`~etspy.align.tilt_com` function.
-        limit
-            (Only used when ``method == "MaxImage"``)
-            Maximum rotation angle for MaxImage calculation
-        delta
-            (Only used when ``method == "MaxImage"``)
-            Angular increment in degrees for MaxImage calculation
-        plot_results
-            (Only used when ``method == "MaxImage"``)
-            If ``True``, plot the maximum image along with the lines determined
-            by Hough analysis
-        also_shift
-            (Only used when ``method == "MaxImage"``)
-            If ``True``, also calculate and apply the global shift perpendicular to the
-            tilt by minimizing the sum of the reconstruction
-        shift_limit
-            (Only used when ``method == "MaxImage"``)
-            The limit of shifts applied if ``also_shift`` is set to ``True``
+        **kwargs:
+            Remaining keyword arguments are passed to the underlying alignment
+            functions.
+
+        Keyword arguments that may be used include:
+            slices
+                (Only used when ``method == "CoM"``)
+                Locations at which to perform the Center of Mass analysis. If not
+                provided, an appropriate list of slices will be automatically
+                determined.
+            nslices
+                (Only used when ``method == "CoM"``)
+                Nubmer of slices to use for the center of mass analysis (only used if
+                the ``slices`` parameter is not specified). If ``None``, a value of 10%
+                of the x-axis size will be used, clamped to the range [3, 50], as
+                calculated in the :py:func:`~etspy.align.TiltCOMAligner` class.
+            limit
+                (Only used when ``method == "MaxImage"``)
+                Maximum rotation angle for MaxImage calculation
+            delta
+                (Only used when ``method == "MaxImage"``)
+                Angular increment in degrees for MaxImage calculation
+            plot_results
+                (Only used when ``method == "MaxImage"``)
+                If ``True``, plot the maximum image along with the lines determined
+                by Hough analysis
+            also_shift
+                (Only used when ``method == "MaxImage"``)
+                If ``True``, also calculate and apply the global shift perpendicular to
+                the tilt by minimizing the sum of the reconstruction
+            shift_limit
+                (Only used when ``method == "MaxImage"``)
+                The limit of shifts applied if ``also_shift`` is set to ``True``
 
         Returns
         -------
         out : TomoStack
-            Copy of the input stack rotated by calculated angle
+            Copy of the input stack corrected for tilt axis alignment
 
         Examples
         --------
@@ -1537,17 +1537,17 @@ class TomoStack(CommonStack):
             >>> method = 'MaxImage'
             >>> ali = reg.tilt_align(method)
         """
-        if method == "CoM":
-            out = align.tilt_com(self, slices, nslices)
-        elif method == "MaxImage":
-            out = align.tilt_maximage(
-                self,
-                limit,
-                delta,
-                plot_results,
-                also_shift,
-                shift_limit,
-            )
+        tilt_aligners = {
+            "CoM": align.TiltCOMAligner,
+            "MaxImage": align.TiltMaxImageAligner,
+        }
+
+        if method in [
+            "CoM",
+            "MaxImage",
+        ]:
+            tilt_aligner = tilt_aligners[method](self, **kwargs)
+            out = tilt_aligner.align_tilt_axis()
         else:
             msg = (
                 f'Invalid alignment method "{method}". Must be one of '

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -46,10 +46,14 @@ has_cupy = True
 try:
     import cupy as cp  # type: ignore
     from cupyx.scipy.ndimage import affine_transform as affine_transform_gpu
+
+    has_gpu = cp.cuda.runtime.getDeviceCount() > 0
+
 except (ImportError, ModuleNotFoundError):
     has_cupy = False
     cp = None
     affine_transform_gpu = None
+
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -1432,9 +1432,9 @@ class TomoStack(CommonStack):
         if AlignmentMethod.is_valid_value(method):
             aligner = aligners[method](
                 self,
-                start,
-                show_progressbar,
-                cuda,
+                start=start,
+                show_progressbar=show_progressbar,
+                cuda=cuda,
                 **kwargs,
             )
             out = aligner.align(shift_type)

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -1431,9 +1431,13 @@ class TomoStack(CommonStack):
 
         if AlignmentMethod.is_valid_value(method):
             aligner = aligners[method](
-                self, start, show_progressbar, cuda, crop, shift_type, **kwargs
+                self,
+                start,
+                show_progressbar,
+                cuda,
+                **kwargs,
             )
-            out = aligner.align()
+            out = aligner.align(shift_type)
         else:
             msg = (
                 f'Invalid registration method "{method}". '

--- a/etspy/base.py
+++ b/etspy/base.py
@@ -1320,7 +1320,7 @@ class TomoStack(CommonStack):
             )
         return filtered
 
-    def stack_register(  # noqa: PLR0913
+    def stack_register(
         self,
         method: AlignmentMethodType = AlignmentMethod.PC,
         start: int | None = None,
@@ -1357,7 +1357,8 @@ class TomoStack(CommonStack):
             scipy.ndimage.shift or via Fourier shift as implemented in
             scipy.ndimage.fourier_shift.  Must be either 'interp' or 'fourier'.
         **kwargs:
-            Remaining keyword arguments are passed to the underlying alignment functions.
+            Remaining keyword arguments are passed to the underlying alignment
+            functions.
 
         Keyword arguments that may be used include:
             xrange
@@ -1366,8 +1367,8 @@ class TomoStack(CommonStack):
                 :py:func:`~etspy.align.calculate_shifts_com` for more details.
             p
                 (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM`)
-                Padding element. See :py:func:`~etspy.align.calculate_shifts_com` for more
-                details.
+                Padding element. See :py:func:`~etspy.align.calculate_shifts_com` for
+                more details.
             nslices
                 (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM`)
                 Number of slices to return. See
@@ -1376,8 +1377,8 @@ class TomoStack(CommonStack):
                 (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
                 Reference slice for center of mass alignment.  All other slices
                 will be aligned to this reference.  If not provided, the midpoint
-                of the stack will be chosen. See :py:func:`~etspy.align.calc_shifts_com_cl`
-                for more details.
+                of the stack will be chosen.
+                See :py:func:`~etspy.align.calc_shifts_com_cl` for more details.
             cl_ref_index
                 (Only used when ``method ==``:py:attr:`~etspy.AlignmentMethod.COM_CL`)
                 Reference slice for common line alignment.  All other slices

--- a/etspy/tests/test_align.py
+++ b/etspy/tests/test_align.py
@@ -245,13 +245,14 @@ class TestTiltAlign:
         assert tilt_axis == pytest.approx(-3.2, abs=0.5)
 
     def test_tilt_align_com_no_tilts(self, aligned_full_stack):
-        del aligned_full_stack.tilts
+        stack_no_tilts = aligned_full_stack.deepcopy()
+        del stack_no_tilts.tilts
         with pytest.raises(
             ValueError,
             match=r"Tilts are not defined in stack.tilts \(values were all zeros\). "
             r"Please set tilt values before alignment.",
         ):
-            aligned_full_stack.tilt_align(method="CoM", slices=np.array([64, 128, 192]))
+            stack_no_tilts.tilt_align(method="CoM", slices=np.array([64, 128, 192]))
 
     def test_tilt_align_maximage(self, aligned_full_stack):
         assert aligned_full_stack.metadata.get_item("Tomography.tiltaxis") == 0
@@ -276,7 +277,8 @@ class TestTiltAlign:
     def test_tilt_align_maximage_also_shift(self, aligned_full_stack):
         assert aligned_full_stack.metadata.get_item("Tomography.tiltaxis") == 0
         maximage_tilt_aligner = etspy.align.TiltMaxImageAligner(
-            aligned_full_stack, also_shift=True
+            aligned_full_stack,
+            also_shift=True,
         )
         ali = maximage_tilt_aligner.align_tilt_axis()
         tilt_axis = ali.metadata.get_item("Tomography.tiltaxis")

--- a/etspy/tests/test_align.py
+++ b/etspy/tests/test_align.py
@@ -70,33 +70,33 @@ class TestAlignFunctions:
         claligner = etspy.align.CommonLineAligner(short_stack)
         line = np.zeros(100)
         padding = 200
-        padded = claligner._pad_line(line, padding)
+        padded = claligner.pad_line(line, padding)
         assert padded.shape[0] == padding
 
     def test_pad_line_uneven_line(self, short_stack):
         claligner = etspy.align.CommonLineAligner(short_stack)
         line = np.zeros(101)
         padding = 200
-        padded = claligner._pad_line(line, padding)
+        padded = claligner.pad_line(line, padding)
         assert padded.shape[0] == padding
 
     def test_pad_line_uneven_padded(self, short_stack):
         claligner = etspy.align.CommonLineAligner(short_stack)
         line = np.zeros(100)
         padding = 201
-        padded = claligner._pad_line(line, padding)
+        padded = claligner.pad_line(line, padding)
         assert padded.shape[0] == padding
 
     def test_pad_line_uneven_both(self, short_stack):
         claligner = etspy.align.CommonLineAligner(short_stack)
         line = np.zeros(101)
         padding = 201
-        padded = claligner._pad_line(line, padding)
+        padded = claligner.pad_line(line, padding)
         assert padded.shape[0] == padding
 
     def test_calc_shifts_cl_no_index(self, full_stack):
         claligner = etspy.align.CommonLineAligner(full_stack)
-        shifts = claligner._calc_shifts_cl(None, 0.05, 8)
+        shifts = claligner.calc_shifts_cl(None, 0.05, 8)
         assert isinstance(shifts, np.ndarray)
         assert shifts.shape == (77,)
 
@@ -168,9 +168,9 @@ class TestCUDAAlignFunctions:
 
     def test_cuda_cpu_consistency(self, short_stack):
         reg_cuda = short_stack.stack_register("PC", cuda=True)
-        shifts_cuda = reg_cuda._shifts.data
+        shifts_cuda = reg_cuda.shifts.data
         reg_cpu = short_stack.stack_register("PC", cuda=False)
-        shifts_cpu = reg_cpu._shifts.data
+        shifts_cpu = reg_cpu.shifts.data
         assert np.abs(shifts_cuda[0:5] - shifts_cpu[0:5]).sum() < 1.0
 
 
@@ -255,7 +255,8 @@ class TestTiltAlign:
         # also_shift should result in a yshift for the aligned stack
         assert aligned_full_stack.metadata.get_item("Tomography.yshift") == 0
         assert ali.metadata.get_item("Tomography.yshift") == pytest.approx(
-            2.0, rel=1e-1
+            2.0,
+            rel=1e-1,
         )
 
     def test_tilt_align_unknown_method(self, full_stack):

--- a/etspy/tests/test_align.py
+++ b/etspy/tests/test_align.py
@@ -38,6 +38,22 @@ def full_stack():
     return ds.get_needle_data()
 
 
+@pytest.fixture(scope="module")
+def aligned_short_stack():
+    """Create truncated and spatially registered stack from test data."""
+    s = ds.get_needle_data().inav[0:5]
+    s = s.stack_register("PC")
+    return s
+
+
+@pytest.fixture(scope="module")
+def aligned_full_stack():
+    """Create full spatially registered stack from test data."""
+    s = ds.get_needle_data()
+    s = s.stack_register("PC")
+    return s
+
+
 class TestAlignFunctions:
     """Test alignment functions."""
 
@@ -117,14 +133,13 @@ class TestAlignFunctions:
             etspy.align.tilt_com(full_stack, slices=None, nslices=300)
 
     def test_tilt_com_nx_threshold_error(self, full_stack):
-        stack = full_stack.isig[:2, :]
         with pytest.raises(
             ValueError,
             match=(
                 r"Dataset is only 2 pixels in x dimension. This method cannot be used."
             ),
         ):
-            etspy.align.tilt_com(stack)
+            etspy.align.tilt_com(full_stack.isig[:2, :])
 
     def test_calc_shifts_com_cl_res_error(self, full_stack):
         claligner = etspy.align.CommonLineAligner(
@@ -151,6 +166,13 @@ class TestCUDAAlignFunctions:
         reload(sys.modules["etspy.align"])
         assert etspy.align.has_cupy
 
+    def test_cuda_cpu_consistency(self, short_stack):
+        reg_cuda = short_stack.stack_register("PC", cuda=True)
+        shifts_cuda = reg_cuda._shifts.data
+        reg_cpu = short_stack.stack_register("PC", cuda=False)
+        shifts_cpu = reg_cpu._shifts.data
+        assert np.abs(shifts_cuda[0:5] - shifts_cpu[0:5]).sum() < 1.0
+
 
 class TestAlignStackRegister:
     """Test alignment using stack reg."""
@@ -173,8 +195,7 @@ class TestAlignStackRegister:
             == short_stack.axes_manager.navigation_shape
         )
 
-    def test_register_unknown_method(self):
-        stack = ds.get_needle_data()
+    def test_register_unknown_method(self, short_stack):
         bad_method = "WRONG"
         with pytest.raises(
             TypeError,
@@ -183,71 +204,61 @@ class TestAlignStackRegister:
                 'Must be one of ["StackReg", "PC", "COM", or "COM-CL"].',
             ),
         ):
-            stack.inav[0:20].stack_register(bad_method)  # type: ignore
+            short_stack.stack_register(bad_method)  # type: ignore
 
 
 class TestTiltAlign:
     """Test tilt alignment functions."""
 
-    def test_tilt_align_com(self):
-        stack = ds.get_needle_data()
-        reg = stack.stack_register("PC")
-        ali = reg.tilt_align(method="CoM", slices=np.array([64, 128, 192]))
+    def test_tilt_align_com(self, aligned_full_stack):
+        ali = aligned_full_stack.tilt_align(
+            method="CoM",
+            slices=np.array([32, 64, 96, 128, 160]),
+        )
         tilt_axis = cast("Dtb", ali.metadata.Tomography).tiltaxis
-        assert abs(-2.7 - cast("float", tilt_axis)) < 1.0
+        assert tilt_axis == pytest.approx(-2.7, abs=0.5)
 
-    def test_tilt_align_com_no_locs(self):
-        stack = ds.get_needle_data()
-        reg = stack.stack_register("PC")
-        ali = reg.tilt_align(method="CoM", slices=None, nslices=None)
+    def test_tilt_align_com_no_locs(self, aligned_full_stack):
+        ali = aligned_full_stack.tilt_align(method="CoM", slices=None, nslices=None)
         tilt_axis = cast("Dtb", ali.metadata.Tomography).tiltaxis
-        assert abs(-2.7 - cast("float", tilt_axis)) < 1.0
+        assert tilt_axis == pytest.approx(-3.2, abs=0.5)
 
-    def test_tilt_align_com_no_tilts(self):
-        stack = ds.get_needle_data()
-        reg = stack.stack_register("PC")
-        del reg.tilts
+    def test_tilt_align_com_no_tilts(self, aligned_full_stack):
+        del aligned_full_stack.tilts
         with pytest.raises(
             ValueError,
             match=r"Tilts are not defined in stack.tilts \(values were all zeros\). "
             r"Please set tilt values before alignment.",
         ):
-            reg.tilt_align(method="CoM", slices=np.array([64, 128, 192]))
+            aligned_full_stack.tilt_align(method="CoM", slices=np.array([64, 128, 192]))
 
-    def test_tilt_align_maximage(self):
-        stack = ds.get_needle_data()
-        stack = stack.inav[0:5]
-        reg = stack.stack_register("PC", shift_type="interp")
-        assert reg.metadata.get_item("Tomography.tiltaxis") == 0
-        ali = reg.tilt_align(method="MaxImage")
+    def test_tilt_align_maximage(self, aligned_full_stack):
+        assert aligned_full_stack.metadata.get_item("Tomography.tiltaxis") == 0
+        ali = aligned_full_stack.tilt_align(method="MaxImage")
         tilt_axis = ali.metadata.get_item("Tomography.tiltaxis")
         assert isinstance(tilt_axis, float)
-        assert tilt_axis == pytest.approx(-0.5)
+        assert round(tilt_axis, 1) == pytest.approx(-2.3, rel=1e-1)
         # shifts should be what they were before tilt_align:
-        assert np.all(ali.shifts.data == reg.shifts.data)
+        assert np.all(ali.shifts.data == aligned_full_stack.shifts.data)
 
     # @pytest.mark.mpl_image_compare(remove_text=True)
-    def test_tilt_align_maximage_plot_results(self):
-        stack = ds.get_needle_data()
-        stack = stack.inav[0:5]
-        reg = stack.stack_register("PC")
+    def test_tilt_align_maximage_plot_results(self, aligned_short_stack):
+        reg = aligned_short_stack.stack_register("PC")
         reg.tilt_align(method="MaxImage", plot_results=True)
 
-    def test_tilt_align_maximage_also_shift(self):
-        stack = ds.get_needle_data()
-        stack = stack.inav[0:5]
-        reg = stack.stack_register("PC", shift_type="interp")
-        assert reg.metadata.get_item("Tomography.tiltaxis") == 0
-        ali = reg.tilt_align(method="MaxImage", also_shift=True)
+    def test_tilt_align_maximage_also_shift(self, aligned_full_stack):
+        assert aligned_full_stack.metadata.get_item("Tomography.tiltaxis") == 0
+        ali = aligned_full_stack.tilt_align(method="MaxImage", also_shift=True)
         tilt_axis = ali.metadata.get_item("Tomography.tiltaxis")
         assert isinstance(tilt_axis, float)
-        assert tilt_axis == pytest.approx(-0.5)
+        assert round(tilt_axis, 1) == pytest.approx(-2.3, rel=1e-1)
         # also_shift should result in a yshift for the aligned stack
-        assert reg.metadata.get_item("Tomography.yshift") == 0
-        assert ali.metadata.get_item("Tomography.yshift") == pytest.approx(-19)
+        assert aligned_full_stack.metadata.get_item("Tomography.yshift") == 0
+        assert ali.metadata.get_item("Tomography.yshift") == pytest.approx(
+            2.0, rel=1e-1
+        )
 
-    def test_tilt_align_unknown_method(self):
-        stack = ds.get_needle_data()
+    def test_tilt_align_unknown_method(self, full_stack):
         bad_method = "WRONG"
         with pytest.raises(
             ValueError,
@@ -256,46 +267,38 @@ class TestTiltAlign:
                 'Must be one of ["CoM" or "MaxImage"].',
             ),
         ):
-            stack.tilt_align(method=bad_method)  # type: ignore
+            full_stack.tilt_align(method=bad_method)  # type: ignore
 
 
 class TestAlignOther:
     """Test alignment of a dataset calculated for another."""
 
-    def test_align_to_other(self):
-        stack = ds.get_needle_data()
-        stack = stack.inav[0:5]
-        stack2 = stack.deepcopy()
-        reg = stack.stack_register("PC")
-        reg2 = reg.align_other(stack2)
+    def test_align_to_other(self, short_stack):
+        original_stack = short_stack.deepcopy()
+        reg = short_stack.stack_register("PC")
+        reg2 = reg.align_other(original_stack)
         diff = reg.data - reg2.data
         assert diff.sum() == 0.0
 
-    def test_align_to_other_no_alignment(self):
-        stack = ds.get_needle_data()
-        stack = stack.inav[0:5]
-        stack2 = stack.deepcopy()
-        reg = stack.deepcopy()
+    def test_align_to_other_no_alignment(self, short_stack):
+        original_stack = short_stack.deepcopy()
+        reg = short_stack.deepcopy()
         with pytest.raises(
             ValueError,
             match="No transformations have been applied to this stack",
         ):
-            reg.align_other(stack2)
+            reg.align_other(original_stack)
 
-    def test_align_to_other_with_crop(self):
-        stack = ds.get_needle_data()
-        stack = stack.inav[0:5]
-        reg = stack.stack_register("PC", crop=True)
-        reg2 = reg.align_other(stack)
+    def test_align_to_other_with_crop(self, short_stack):
+        reg = short_stack.stack_register("PC", crop=True)
+        reg2 = reg.align_other(short_stack)
         diff = reg.data - reg2.data
         assert diff.sum() == 0.0
 
-    def test_align_to_other_with_xshift(self):
-        stack = ds.get_needle_data()
-        stack = stack.inav[0:5]
-        stack2 = stack.deepcopy()
-        reg = stack.stack_register("PC")
+    def test_align_to_other_with_xshift(self, short_stack):
+        original_stack = short_stack.deepcopy()
+        reg = original_stack.stack_register("PC")
         reg = cast("etspy.TomoStack", reg.trans_stack(xshift=10, yshift=5, angle=2))
-        reg2 = reg.align_other(stack2)
+        reg2 = reg.align_other(original_stack)
         diff = reg.data - reg2.data
         assert diff.sum() == 0.0

--- a/etspy/tests/test_align.py
+++ b/etspy/tests/test_align.py
@@ -119,27 +119,42 @@ class TestAlignFunctions:
         assert shifts.shape == (77, 2)
 
     def test_tilt_com_no_slices_yes_nslices_30_perc(self, full_stack, caplog):
-        etspy.align.tilt_com(full_stack, slices=None, nslices=100)
+        com_tilt_aligner = etspy.align.TiltCOMAligner(
+            full_stack,
+            slices=None,
+            nslices=100,
+        )
+        _ = com_tilt_aligner.align_tilt_axis()
         assert (
             "nslices is greater than 30% of number of x pixels. "
             "Using 76 slices instead."
         ) in caplog.text
 
     def test_tilt_com_no_slices_yes_nslices_too_big(self, full_stack):
+        com_tilt_aligner = etspy.align.TiltCOMAligner(
+            full_stack,
+            slices=None,
+            nslices=300,
+        )
         with pytest.raises(
             ValueError,
             match=r"nslices is greater than the X-dimension of the data\.",
         ):
-            etspy.align.tilt_com(full_stack, slices=None, nslices=300)
+            com_tilt_aligner.align_tilt_axis()
 
     def test_tilt_com_nx_threshold_error(self, full_stack):
+        com_tilt_aligner = etspy.align.TiltCOMAligner(
+            full_stack.isig[:2, :],
+            slices=None,
+            nslices=100,
+        )
         with pytest.raises(
             ValueError,
             match=(
                 r"Dataset is only 2 pixels in x dimension. This method cannot be used."
             ),
         ):
-            etspy.align.tilt_com(full_stack.isig[:2, :])
+            com_tilt_aligner.align_tilt_axis()
 
     def test_calc_shifts_com_cl_res_error(self, full_stack):
         claligner = etspy.align.CommonLineAligner(
@@ -211,15 +226,21 @@ class TestTiltAlign:
     """Test tilt alignment functions."""
 
     def test_tilt_align_com(self, aligned_full_stack):
-        ali = aligned_full_stack.tilt_align(
-            method="CoM",
+        com_tilt_aligner = etspy.align.TiltCOMAligner(
+            aligned_full_stack,
             slices=np.array([32, 64, 96, 128, 160]),
         )
+        ali = com_tilt_aligner.align_tilt_axis()
         tilt_axis = cast("Dtb", ali.metadata.Tomography).tiltaxis
         assert tilt_axis == pytest.approx(-2.7, abs=0.5)
 
     def test_tilt_align_com_no_locs(self, aligned_full_stack):
-        ali = aligned_full_stack.tilt_align(method="CoM", slices=None, nslices=None)
+        com_tilt_aligner = etspy.align.TiltCOMAligner(
+            aligned_full_stack,
+            slices=None,
+            nslices=None,
+        )
+        ali = com_tilt_aligner.align_tilt_axis()
         tilt_axis = cast("Dtb", ali.metadata.Tomography).tiltaxis
         assert tilt_axis == pytest.approx(-3.2, abs=0.5)
 
@@ -234,7 +255,10 @@ class TestTiltAlign:
 
     def test_tilt_align_maximage(self, aligned_full_stack):
         assert aligned_full_stack.metadata.get_item("Tomography.tiltaxis") == 0
-        ali = aligned_full_stack.tilt_align(method="MaxImage")
+        maximage_tilt_aligner = etspy.align.TiltMaxImageAligner(
+            aligned_full_stack,
+        )
+        ali = maximage_tilt_aligner.align_tilt_axis()
         tilt_axis = ali.metadata.get_item("Tomography.tiltaxis")
         assert isinstance(tilt_axis, float)
         assert round(tilt_axis, 1) == pytest.approx(-2.3, rel=1e-1)
@@ -243,12 +267,18 @@ class TestTiltAlign:
 
     # @pytest.mark.mpl_image_compare(remove_text=True)
     def test_tilt_align_maximage_plot_results(self, aligned_short_stack):
-        reg = aligned_short_stack.stack_register("PC")
-        reg.tilt_align(method="MaxImage", plot_results=True)
+        maximage_tilt_aligner = etspy.align.TiltMaxImageAligner(
+            aligned_short_stack,
+            plot_results=True,
+        )
+        _ = maximage_tilt_aligner.align_tilt_axis()
 
     def test_tilt_align_maximage_also_shift(self, aligned_full_stack):
         assert aligned_full_stack.metadata.get_item("Tomography.tiltaxis") == 0
-        ali = aligned_full_stack.tilt_align(method="MaxImage", also_shift=True)
+        maximage_tilt_aligner = etspy.align.TiltMaxImageAligner(
+            aligned_full_stack, also_shift=True
+        )
+        ali = maximage_tilt_aligner.align_tilt_axis()
         tilt_axis = ali.metadata.get_item("Tomography.tiltaxis")
         assert isinstance(tilt_axis, float)
         assert round(tilt_axis, 1) == pytest.approx(-2.3, rel=1e-1)

--- a/etspy/tests/test_align.py
+++ b/etspy/tests/test_align.py
@@ -26,89 +26,98 @@ except Exception:
     cupy_in_test_env = False
 
 
+@pytest.fixture(scope="module")
+def short_stack():
+    """Load stack from test data and truncate to 5 images."""
+    return ds.get_needle_data().inav[0:5]
+
+
+@pytest.fixture(scope="module")
+def full_stack():
+    """Load stack from test data."""
+    return ds.get_needle_data()
+
+
 class TestAlignFunctions:
     """Test alignment functions."""
 
-    def test_apply_shifts_bad_shape(self):
-        stack = ds.get_needle_data()
-        stack = stack.inav[0:5]
+    def test_apply_shifts_bad_shape(self, short_stack):
         shifts = np.zeros(10)
         with pytest.raises(
             ValueError,
             match=r"Number of shifts \(\d+\) is not consistent with number of images "
             r"in the stack \(\d+\)",
         ):
-            etspy.align.apply_shifts(stack, shifts)
+            etspy.align.apply_shifts(short_stack, shifts)
 
-    def test_pad_line(self):
+    def test_pad_line(self, short_stack):
+        claligner = etspy.align.CommonLineAligner(short_stack)
         line = np.zeros(100)
         padding = 200
-        padded = etspy.align.pad_line(line, padding)
+        padded = claligner._pad_line(line, padding)
         assert padded.shape[0] == padding
 
-    def test_pad_line_uneven_line(self):
+    def test_pad_line_uneven_line(self, short_stack):
+        claligner = etspy.align.CommonLineAligner(short_stack)
         line = np.zeros(101)
         padding = 200
-        padded = etspy.align.pad_line(line, padding)
+        padded = claligner._pad_line(line, padding)
         assert padded.shape[0] == padding
 
-    def test_pad_line_uneven_padded(self):
+    def test_pad_line_uneven_padded(self, short_stack):
+        claligner = etspy.align.CommonLineAligner(short_stack)
         line = np.zeros(100)
         padding = 201
-        padded = etspy.align.pad_line(line, padding)
+        padded = claligner._pad_line(line, padding)
         assert padded.shape[0] == padding
 
-    def test_pad_line_uneven_both(self):
+    def test_pad_line_uneven_both(self, short_stack):
+        claligner = etspy.align.CommonLineAligner(short_stack)
         line = np.zeros(101)
         padding = 201
-        padded = etspy.align.pad_line(line, padding)
+        padded = claligner._pad_line(line, padding)
         assert padded.shape[0] == padding
 
-    def test_calc_shifts_cl_no_index(self):
-        stack = ds.get_needle_data()
-        shifts = etspy.align.calc_shifts_cl(stack, None, 0.05, 8)
+    def test_calc_shifts_cl_no_index(self, full_stack):
+        claligner = etspy.align.CommonLineAligner(full_stack)
+        shifts = claligner._calc_shifts_cl(None, 0.05, 8)
         assert isinstance(shifts, np.ndarray)
         assert shifts.shape == (77,)
 
-    def test_calc_shifts_com_with_xrange(self):
-        stack = ds.get_needle_data()
-        shifts_def = etspy.align.calculate_shifts_conservation_of_mass(stack)
-        shifts = etspy.align.calculate_shifts_conservation_of_mass(
-            stack,
-            xrange=(31, 225),
-        )
+    def test_calc_shifts_com_with_xrange(self, full_stack):
+        comaligner = etspy.align.CoMAligner(full_stack)
+        shifts_def = comaligner.calculate_shifts()
+        comaligner = etspy.align.CoMAligner(full_stack, xrange=(31, 225))
+        shifts = comaligner.calculate_shifts()
         assert isinstance(shifts, np.ndarray)
         assert np.all(shifts == shifts_def)
 
-    def test_calc_shifts_stackreg_no_start(self):
-        stack = ds.get_needle_data()
-        shifts = etspy.align.calculate_shifts_stackreg(
-            stack,
+    def test_calc_shifts_stackreg_no_start(self, full_stack):
+        sraligner = etspy.align.StackRegAligner(
+            full_stack,
             start=None,
             show_progressbar=False,
         )
+        shifts = sraligner.calculate_shifts()
         assert isinstance(shifts, np.ndarray)
         assert shifts.shape == (77, 2)
 
-    def test_tilt_com_no_slices_yes_nslices_30_perc(self, caplog):
-        stack = ds.get_needle_data()
-        etspy.align.tilt_com(stack, slices=None, nslices=100)
+    def test_tilt_com_no_slices_yes_nslices_30_perc(self, full_stack, caplog):
+        etspy.align.tilt_com(full_stack, slices=None, nslices=100)
         assert (
             "nslices is greater than 30% of number of x pixels. "
             "Using 76 slices instead."
         ) in caplog.text
 
-    def test_tilt_com_no_slices_yes_nslices_too_big(self):
-        stack = ds.get_needle_data()
+    def test_tilt_com_no_slices_yes_nslices_too_big(self, full_stack):
         with pytest.raises(
             ValueError,
             match=r"nslices is greater than the X-dimension of the data\.",
         ):
-            etspy.align.tilt_com(stack, slices=None, nslices=300)
+            etspy.align.tilt_com(full_stack, slices=None, nslices=300)
 
-    def test_tilt_com_nx_threshold_error(self):
-        stack = ds.get_needle_data()
-        stack = stack.isig[:2, :]
+    def test_tilt_com_nx_threshold_error(self, full_stack):
+        stack = full_stack.isig[:2, :]
         with pytest.raises(
             ValueError,
             match=(
@@ -117,23 +126,22 @@ class TestAlignFunctions:
         ):
             etspy.align.tilt_com(stack)
 
-    def test_calc_shifts_com_cl_res_error(self):
-        stack = ds.get_needle_data()
+    def test_calc_shifts_com_cl_res_error(self, full_stack):
+        claligner = etspy.align.CommonLineAligner(
+            full_stack,
+            com_ref_index=30,
+            cl_resolution=0.9,
+        )
         with pytest.raises(ValueError, match=(r"Resolution should be less than 0.5")):
-            etspy.align.calc_shifts_com_cl(
-                stack,
-                com_ref_index=30,
-                cl_resolution=0.9,
-            )
+            claligner.calculate_shifts()
 
 
 @pytest.mark.skipif(not cupy_in_test_env, reason="cupy not available")
 class TestCUDAAlignFunctions:
     """Test alignment functions using CUDA functionality."""
 
-    def test_stack_reg_pc_cuda(self):
-        stack = ds.get_needle_data()
-        stack.stack_register("PC", cuda=True)
+    def test_stack_reg_pc_cuda(self, short_stack):
+        short_stack.stack_register("PC", cuda=True)
 
     def test_no_cupy(self):
         assert etspy.align.has_cupy
@@ -147,52 +155,22 @@ class TestCUDAAlignFunctions:
 class TestAlignStackRegister:
     """Test alignment using stack reg."""
 
-    def test_register_pc(self):
-        stack = ds.get_needle_data()
-        reg = stack.inav[0:20].stack_register("PC")
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "PC",
+            "StackReg",
+            "COM",
+            "COM-CL",
+        ],
+    )
+    def test_register_methods(self, short_stack, method):
+        reg = short_stack.inav[0:20].stack_register(method)
         assert isinstance(reg, etspy.TomoStack)
-        assert (
-            reg.axes_manager.signal_shape == stack.inav[0:20].axes_manager.signal_shape
-        )
+        assert reg.axes_manager.signal_shape == short_stack.axes_manager.signal_shape
         assert (
             reg.axes_manager.navigation_shape
-            == stack.inav[0:20].axes_manager.navigation_shape
-        )
-
-    def test_register_com(self):
-        stack = ds.get_needle_data()
-        reg = stack.inav[0:20].stack_register("COM")
-        assert isinstance(reg, etspy.TomoStack)
-        assert (
-            reg.axes_manager.signal_shape == stack.inav[0:20].axes_manager.signal_shape
-        )
-        assert (
-            reg.axes_manager.navigation_shape
-            == stack.inav[0:20].axes_manager.navigation_shape
-        )
-
-    def test_register_stackreg(self):
-        stack = ds.get_needle_data()
-        reg = stack.inav[0:20].stack_register("StackReg")
-        assert isinstance(reg, etspy.TomoStack)
-        assert (
-            reg.axes_manager.signal_shape == stack.inav[0:20].axes_manager.signal_shape
-        )
-        assert (
-            reg.axes_manager.navigation_shape
-            == stack.inav[0:20].axes_manager.navigation_shape
-        )
-
-    def test_register_com_cl(self):
-        stack = ds.get_needle_data()
-        reg = stack.inav[0:20].stack_register("COM-CL")
-        assert isinstance(reg, etspy.TomoStack)
-        assert (
-            reg.axes_manager.signal_shape == stack.inav[0:20].axes_manager.signal_shape
-        )
-        assert (
-            reg.axes_manager.navigation_shape
-            == stack.inav[0:20].axes_manager.navigation_shape
+            == short_stack.axes_manager.navigation_shape
         )
 
     def test_register_unknown_method(self):
@@ -206,22 +184,6 @@ class TestAlignStackRegister:
             ),
         ):
             stack.inav[0:20].stack_register(bad_method)  # type: ignore
-
-    def test_align_stack_bad_method(self):
-        """
-        Test invalid method in align_stack directly.
-
-        Since we can't through TomoStack.stack_register.
-        """
-        stack = ds.get_needle_data()
-        bad_method = "WRONG"
-        with pytest.raises(ValueError, match=f"Invalid alignment method {bad_method}"):
-            etspy.align.align_stack(
-                stack,
-                method=bad_method,  # pyright: ignore[reportArgumentType]
-                start=None,
-                show_progressbar=False,
-            )
 
 
 class TestTiltAlign:

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -21,6 +21,7 @@ from matplotlib.figure import Figure
 
 from etspy import datasets as ds
 from etspy.base import CommonStack, RecStack, TomoShifts, TomoStack, TomoTilts
+from etspy.align import TiltCOMAligner, TiltMaxImageAligner
 
 from . import load_serialem_multiframe_data
 
@@ -1245,13 +1246,20 @@ class TestTiltAlign:
 
     def test_tilt_align_com_axis_zero(self):
         stack = ds.get_needle_data(aligned=True)
-        ali = stack.tilt_align("CoM", slices=np.array([64, 100, 114]))
+        com_tilt_aligner = TiltCOMAligner(
+            stack,
+            slices=np.array([64, 100, 114]),
+        )
+        ali = com_tilt_aligner.align_tilt_axis()
         assert isinstance(ali, TomoStack)
 
     def test_tilt_align_maximage(self):
         stack = ds.get_needle_data(aligned=True)
         stack = stack.inav[0:10]
-        ali = stack.tilt_align("MaxImage")
+        maximage_tilt_aligner = TiltMaxImageAligner(
+            stack,
+        )
+        ali = maximage_tilt_aligner.align_tilt_axis()
         assert isinstance(ali, TomoStack)
 
     def test_tilt_align_unknown_method(self):

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -20,8 +20,8 @@ from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
 
 from etspy import datasets as ds
-from etspy.base import CommonStack, RecStack, TomoShifts, TomoStack, TomoTilts
 from etspy.align import TiltCOMAligner, TiltMaxImageAligner
+from etspy.base import CommonStack, RecStack, TomoShifts, TomoStack, TomoTilts
 
 from . import load_serialem_multiframe_data
 

--- a/etspy/tests/test_cuda.py
+++ b/etspy/tests/test_cuda.py
@@ -19,10 +19,9 @@ try:
     import cupy as cp
 
     has_gpu = cp.cuda.runtime.getDeviceCount() > 0
-    from etspy.align import apply_shifts_cuda
+    from etspy.align import apply_shifts  # type: ignore
 except Exception:
     cupy_in_test_env = False
-    apply_shifts_cuda = None
 
 NUM_FIG_AXES = 3
 
@@ -217,7 +216,7 @@ class TestApplyShiftsCUDA:
     def test_apply_shifts_fourier_cuda(self):
         stack = ds.get_needle_data(aligned=False)
         shifts = np.random.uniform(-2, 2, [20, 2])
-        shifted = apply_shifts_cuda(stack.inav[0:20], shifts, "fourier")
+        shifted = apply_shifts(stack.inav[0:20], shifts, "fourier", cuda=True)  # type: ignore
         assert isinstance(shifted, TomoStack)
         assert (
             shifted.axes_manager.signal_shape
@@ -231,7 +230,7 @@ class TestApplyShiftsCUDA:
     def test_apply_shifts_interp_cuda(self):
         stack = ds.get_needle_data(aligned=False)
         shifts = np.random.uniform(-2, 2, [20, 2])
-        shifted = apply_shifts_cuda(stack.inav[0:20], shifts, "interp")
+        shifted = apply_shifts(stack.inav[0:20], shifts, "interp", cuda=True)  # type: ignore
         assert isinstance(shifted, TomoStack)
         assert (
             shifted.axes_manager.signal_shape

--- a/etspy/transform.py
+++ b/etspy/transform.py
@@ -8,6 +8,8 @@ import numpy as np
 from IPython.display import display
 from scipy import ndimage
 
+from etspy.base import TomoStack
+
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
@@ -15,7 +17,13 @@ logger.setLevel(logging.INFO)
 class VolumeRotator:
     """_Class for interactive rotation of a volume."""
 
-    def __init__(self, stack, order=3, slices=None, figsize=(10, 4)):
+    def __init__(
+        self,
+        stack: TomoStack,
+        order: int = 3,
+        slices: list | np.ndarray | None = None,
+        figsize: tuple = (10, 4),
+    ):
         """Initialize the VolumeRotator Class.
 
         Parameters
@@ -28,6 +36,8 @@ class VolumeRotator:
         """
         if slices is None:
             slices = np.array(stack.data.shape) // 2
+        elif type(slices) is list:
+            slices = np.array(slices)
         self.order = order
         self.xslice = stack.data[slices[0], :, :]
         self.zslice = stack.data[:, slices[1], :].T

--- a/etspy/transform.py
+++ b/etspy/transform.py
@@ -1,6 +1,7 @@
 """Tranformation module for ETSpy package."""
 
 import logging
+from typing import TYPE_CHECKING
 
 import ipywidgets as widgets
 import matplotlib.pyplot as plt
@@ -8,7 +9,8 @@ import numpy as np
 from IPython.display import display
 from scipy import ndimage
 
-from etspy.base import TomoStack
+if TYPE_CHECKING:
+    from etspy.base import TomoStack
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -19,7 +21,7 @@ class VolumeRotator:
 
     def __init__(
         self,
-        stack: TomoStack,
+        stack: "TomoStack",
         order: int = 3,
         slices: list | np.ndarray | None = None,
         figsize: tuple | None = (10, 4),

--- a/etspy/transform.py
+++ b/etspy/transform.py
@@ -22,7 +22,7 @@ class VolumeRotator:
         stack: TomoStack,
         order: int = 3,
         slices: list | np.ndarray | None = None,
-        figsize: tuple = (10, 4),
+        figsize: tuple | None = (10, 4),
     ):
         """Initialize the VolumeRotator Class.
 

--- a/etspy/utils.py
+++ b/etspy/utils.py
@@ -12,7 +12,6 @@ from scipy import ndimage
 
 from etspy import _format_choices as _fmt
 from etspy import _get_literal_hint_values as _get_lit
-from etspy.align import calculate_shifts_stackreg
 from etspy.base import TomoStack
 
 if TYPE_CHECKING:
@@ -61,75 +60,75 @@ def multiaverage(stack: np.ndarray, nframes: int, ny: int, nx: int) -> np.ndarra
     return average
 
 
-def register_serialem_stack(stack: Signal2D, ncpus: int = 1) -> TomoStack:
-    """
-    Register a multi-frame series collected by SerialEM.
+# def register_serialem_stack(stack: Signal2D, ncpus: int = 1) -> TomoStack:
+#     """
+#     Register a multi-frame series collected by SerialEM.
 
-    Parameters
-    ----------
-    stack
-        Signal of shape [ntilts, nframes, ny, nx].
+#     Parameters
+#     ----------
+#     stack
+#         Signal of shape [ntilts, nframes, ny, nx].
 
-    Returns
-    -------
-    reg : TomoStack
-        Result of aligning and averaging frames at each tilt with shape [ntilts, ny, nx]
+#     Returns
+#     -------
+#     reg : TomoStack
+#         Result of aligning and averaging frames at each tilt with shape [ntilts, ny, nx]
 
-    Group
-    -----
-    utilities
-    """
-    align_logger = logging.getLogger("etspy.align")
-    log_level = align_logger.getEffectiveLevel()
-    align_logger.setLevel(logging.ERROR)
-    ntilts, nframes, ny, nx = stack.data.shape
+#     Group
+#     -----
+#     utilities
+#     """
+#     align_logger = logging.getLogger("etspy.align")
+#     log_level = align_logger.getEffectiveLevel()
+#     align_logger.setLevel(logging.ERROR)
+#     ntilts, nframes, ny, nx = stack.data.shape
 
-    if ncpus == 1:
-        reg = np.zeros([ntilts, ny, nx], stack.data.dtype)
-        for i in tqdm.tqdm(range(ntilts)):
-            shifted = np.zeros([nframes, ny, nx])
-            shifts = calculate_shifts_stackreg(
-                stack.inav[:, i],
-                start=None,
-                show_progressbar=False,
-            )
-            for k in range(nframes):
-                shifted[k, :, :] = ndimage.shift(
-                    stack.data[i, k, :, :],
-                    shift=[shifts[k, 0], shifts[k, 1]],
-                )
-            reg[i, :, :] = shifted.mean(0)
-    else:
-        with Pool(ncpus) as pool:
-            reg = pool.starmap(
-                multiaverage,
-                [(stack.inav[:, i].data, nframes, ny, nx) for i in range(ntilts)],
-            )
-        reg = np.array(reg)
+#     if ncpus == 1:
+#         reg = np.zeros([ntilts, ny, nx], stack.data.dtype)
+#         for i in tqdm.tqdm(range(ntilts)):
+#             shifted = np.zeros([nframes, ny, nx])
+#             shifts = calculate_shifts_stackreg(
+#                 stack.inav[:, i],
+#                 start=None,
+#                 show_progressbar=False,
+#             )
+#             for k in range(nframes):
+#                 shifted[k, :, :] = ndimage.shift(
+#                     stack.data[i, k, :, :],
+#                     shift=[shifts[k, 0], shifts[k, 1]],
+#                 )
+#             reg[i, :, :] = shifted.mean(0)
+#     else:
+#         with Pool(ncpus) as pool:
+#             reg = pool.starmap(
+#                 multiaverage,
+#                 [(stack.inav[:, i].data, nframes, ny, nx) for i in range(ntilts)],
+#             )
+#         reg = np.array(reg)
 
-    reg = TomoStack(reg)
-    reg_ax_0, reg_ax_1, reg_ax_2 = (cast("Uda", reg.axes_manager[i]) for i in range(3))
-    stack_ax_1, stack_ax_2, stack_ax_3 = (
-        cast("Uda", stack.axes_manager[i]) for i in range(1, 4)
-    )
-    reg_ax_0.scale = stack_ax_1.scale
-    reg_ax_0.offset = stack_ax_1.offset
-    reg_ax_0.units = stack_ax_1.units
+#     reg = TomoStack(reg)
+#     reg_ax_0, reg_ax_1, reg_ax_2 = (cast("Uda", reg.axes_manager[i]) for i in range(3))
+#     stack_ax_1, stack_ax_2, stack_ax_3 = (
+#         cast("Uda", stack.axes_manager[i]) for i in range(1, 4)
+#     )
+#     reg_ax_0.scale = stack_ax_1.scale
+#     reg_ax_0.offset = stack_ax_1.offset
+#     reg_ax_0.units = stack_ax_1.units
 
-    reg_ax_1.scale = stack_ax_2.scale
-    reg_ax_1.offset = stack_ax_2.offset
-    reg_ax_1.units = stack_ax_2.units
+#     reg_ax_1.scale = stack_ax_2.scale
+#     reg_ax_1.offset = stack_ax_2.offset
+#     reg_ax_1.units = stack_ax_2.units
 
-    reg_ax_2.scale = stack_ax_3.scale
-    reg_ax_2.offset = stack_ax_3.offset
-    reg_ax_2.units = stack_ax_3.units
+#     reg_ax_2.scale = stack_ax_3.scale
+#     reg_ax_2.offset = stack_ax_3.offset
+#     reg_ax_2.units = stack_ax_3.units
 
-    if stack.metadata.has_item("Acquisition_instrument"):
-        reg.metadata.Acquisition_instrument = stack.metadata.Acquisition_instrument
-    if stack.metadata.has_item("Tomography"):
-        reg.metadata.Tomography = stack.metadata.Tomography
-    align_logger.setLevel(log_level)
-    return reg
+#     if stack.metadata.has_item("Acquisition_instrument"):
+#         reg.metadata.Acquisition_instrument = stack.metadata.Acquisition_instrument
+#     if stack.metadata.has_item("Tomography"):
+#         reg.metadata.Tomography = stack.metadata.Tomography
+#     align_logger.setLevel(log_level)
+#     return reg
 
 
 def weight_stack(

--- a/etspy/utils.py
+++ b/etspy/utils.py
@@ -60,75 +60,74 @@ def multiaverage(stack: np.ndarray, nframes: int, ny: int, nx: int) -> np.ndarra
     return average
 
 
-# def register_serialem_stack(stack: Signal2D, ncpus: int = 1) -> TomoStack:
-#     """
-#     Register a multi-frame series collected by SerialEM.
+# TODO: Create Multistack class to handle edge case of multi-frame stacks
+def register_serialem_stack(stack: Signal2D, ncpus: int = 1) -> TomoStack:
+    """
+    Register a multi-frame series collected by SerialEM.
 
-#     Parameters
-#     ----------
-#     stack
-#         Signal of shape [ntilts, nframes, ny, nx].
+    Parameters
+    ----------
+    stack
+        Signal of shape [ntilts, nframes, ny, nx].
 
-#     Returns
-#     -------
-#     reg : TomoStack
-#         Result of aligning and averaging frames at each tilt with shape [ntilts, ny, nx]
+    Returns
+    -------
+    reg : TomoStack
+        Result of aligning and averaging frames at each tilt with shape [ntilts, ny, nx]
 
-#     Group
-#     -----
-#     utilities
-#     """
-#     align_logger = logging.getLogger("etspy.align")
-#     log_level = align_logger.getEffectiveLevel()
-#     align_logger.setLevel(logging.ERROR)
-#     ntilts, nframes, ny, nx = stack.data.shape
+    Group
+    -----
+    utilities
+    """
+    align_logger = logging.getLogger("etspy.align")
+    log_level = align_logger.getEffectiveLevel()
+    align_logger.setLevel(logging.ERROR)
+    ntilts, nframes, ny, nx = stack.data.shape
 
-#     if ncpus == 1:
-#         reg = np.zeros([ntilts, ny, nx], stack.data.dtype)
-#         for i in tqdm.tqdm(range(ntilts)):
-#             shifted = np.zeros([nframes, ny, nx])
-#             shifts = calculate_shifts_stackreg(
-#                 stack.inav[:, i],
-#                 start=None,
-#                 show_progressbar=False,
-#             )
-#             for k in range(nframes):
-#                 shifted[k, :, :] = ndimage.shift(
-#                     stack.data[i, k, :, :],
-#                     shift=[shifts[k, 0], shifts[k, 1]],
-#                 )
-#             reg[i, :, :] = shifted.mean(0)
-#     else:
-#         with Pool(ncpus) as pool:
-#             reg = pool.starmap(
-#                 multiaverage,
-#                 [(stack.inav[:, i].data, nframes, ny, nx) for i in range(ntilts)],
-#             )
-#         reg = np.array(reg)
+    if ncpus == 1:
+        reg = np.zeros([ntilts, ny, nx], stack.data.dtype)
+        sr = StackReg(StackReg.TRANSLATION)
+        for i in tqdm.tqdm(range(ntilts)):
+            shifts = sr.register_stack(stack.data[i], reference="previous")
+            shifts = -np.array([i[0:2, 2][::-1] for i in shifts])
+            shifted = np.zeros([nframes, ny, nx])
+            for k in range(nframes):
+                shifted[k, :, :] = ndimage.shift(
+                    stack.data[i, k, :, :],
+                    shift=[shifts[k, 0], shifts[k, 1]],
+                )
+            reg[i, :, :] = shifted.mean(0)
+    else:
+        with Pool(ncpus) as pool:
+            reg = pool.starmap(
+                multiaverage,
+                [(stack.inav[:, i].data, nframes, ny, nx) for i in range(ntilts)],
+            )
+        reg = np.array(reg)
 
-#     reg = TomoStack(reg)
-#     reg_ax_0, reg_ax_1, reg_ax_2 = (cast("Uda", reg.axes_manager[i]) for i in range(3))
-#     stack_ax_1, stack_ax_2, stack_ax_3 = (
-#         cast("Uda", stack.axes_manager[i]) for i in range(1, 4)
-#     )
-#     reg_ax_0.scale = stack_ax_1.scale
-#     reg_ax_0.offset = stack_ax_1.offset
-#     reg_ax_0.units = stack_ax_1.units
+    reg = TomoStack(reg)
+    reg_ax_0, reg_ax_1, reg_ax_2 = (cast("Uda", reg.axes_manager[i]) for i in range(3))
+    stack_ax_1, stack_ax_2, stack_ax_3 = (
+        cast("Uda", stack.axes_manager[i]) for i in range(1, 4)
+    )
+    reg_ax_0.scale = stack_ax_1.scale
+    reg_ax_0.offset = stack_ax_1.offset
+    reg_ax_0.units = stack_ax_1.units
 
-#     reg_ax_1.scale = stack_ax_2.scale
-#     reg_ax_1.offset = stack_ax_2.offset
-#     reg_ax_1.units = stack_ax_2.units
+    reg_ax_1.scale = stack_ax_2.scale
+    reg_ax_1.offset = stack_ax_2.offset
+    reg_ax_1.units = stack_ax_2.units
 
-#     reg_ax_2.scale = stack_ax_3.scale
-#     reg_ax_2.offset = stack_ax_3.offset
-#     reg_ax_2.units = stack_ax_3.units
+    reg_ax_2.scale = stack_ax_3.scale
+    reg_ax_2.offset = stack_ax_3.offset
+    reg_ax_2.units = stack_ax_3.units
 
-#     if stack.metadata.has_item("Acquisition_instrument"):
-#         reg.metadata.Acquisition_instrument = stack.metadata.Acquisition_instrument
-#     if stack.metadata.has_item("Tomography"):
-#         reg.metadata.Tomography = stack.metadata.Tomography
-#     align_logger.setLevel(log_level)
-#     return reg
+    if stack.metadata.has_item("Acquisition_instrument"):
+        reg.metadata.Acquisition_instrument = stack.metadata.Acquisition_instrument
+    if stack.metadata.has_item("Tomography"):
+        reg.metadata.Tomography = stack.metadata.Tomography
+    align_logger.setLevel(log_level)
+    return reg
 
 
 def weight_stack(


### PR DESCRIPTION
### Description
This PR refactors the alignment module and related base module code to use a class-based architecture.  Instead of a single, complex alignment function, the code now employs abstract aligner classes (StackAligner and TiltAligner) with subclasses for the various alignment methods (i.e. PC, StackReg, etc).

### Key Changes
- created StackAligner and TiltAligner classes
- Used **kwargs for the TomoStack.stack_register method for simplification
- Combined separate apply_shifts and apply_shifts_cuda functions
- 
### Testing Conducted
- [x] **Linting:** Verified `ruff` and `isort` pass
- [x] **format-checks:** Ensured format-checks were passing 
- [x] **CI:** Ensured that all CI tests are passing
- [x] **pytest:** Ensured all tests pass on local Linux machine