### PR TITLE
Chore/streamline tests

### DIFF
--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -457,7 +457,7 @@ class TestProperties:
     def test_tilt_setter_1d_array(self, full_stack):
         full_stack_random_tilts = full_stack.deepcopy()
         full_stack_random_tilts.tilts = np.random.rand(
-            77
+            77,
         )  # should be coerced to (77, 1)
 
         assert (
@@ -803,7 +803,7 @@ class TestSlicers:
         assert t4.axes_manager[1].name == "y"  # type: ignore
         assert t4.tilts.axes_manager.navigation_shape == ()
         assert t4.shifts.axes_manager.navigation_shape == ()
-        # assert t4.tilts.data[0] == pytest.approx(-0.000488)
+        assert t4.tilts.data[0] == pytest.approx(-0.000488)
 
     def test_single_pixel_nav_slicer(self, short_stack):
         t = short_stack.inav[3]
@@ -1139,8 +1139,7 @@ class TestAlignOther:
 class TestStackRegister:
     """Test StackReg alignment of a TomoStack."""
 
-    def test_stack_register_unknown_method(self):
-        stack = ds.get_needle_data(aligned=False).inav[0:5]
+    def test_stack_register_unknown_method(self, short_stack):
         bad_method = "UNKNOWN"
         with pytest.raises(
             TypeError,
@@ -1149,87 +1148,90 @@ class TestStackRegister:
                 'Must be one of ["StackReg", "PC", "COM", or "COM-CL"].',
             ),
         ):
-            stack.stack_register(bad_method)  # type: ignore
+            short_stack.stack_register(bad_method)  # type: ignore
 
-    def test_stack_register_pc(self):
-        stack = ds.get_needle_data(aligned=False).inav[0:5]
-        reg = stack.stack_register("PC")
+    def test_stack_register_pc(self, short_stack):
+        reg = short_stack.stack_register("PC")
         assert isinstance(reg, TomoStack)
 
-    def test_stack_register_com(self):
-        stack = ds.get_needle_data(aligned=False).inav[0:5]
-        reg = stack.stack_register("COM")
+    def test_stack_register_com(self, short_stack):
+        reg = short_stack.stack_register("COM")
         assert isinstance(reg, TomoStack)
 
-    def test_stack_register_stackreg(self):
-        stack = ds.get_needle_data(aligned=False).inav[0:5]
-        reg = stack.stack_register("COM-CL")
+    def test_stack_register_stackreg(self, short_stack):
+        reg = short_stack.stack_register("COM-CL")
         assert isinstance(reg, TomoStack)
 
-    def test_stack_register_with_crop(self):
-        stack = ds.get_needle_data(aligned=False).inav[0:5]
-        reg = stack.stack_register("PC", crop=True)
+    def test_stack_register_with_crop(self, short_stack):
+        reg = short_stack.stack_register("PC", crop=True)
         assert isinstance(reg, TomoStack)
-        assert np.sum(reg.data.shape) < np.sum(stack.data.shape)
+        assert np.sum(reg.data.shape) < np.sum(short_stack.data.shape)
 
 
 class TestErrorPlots:
     """Test error plots for TomoStack."""
 
-    def test_sirt_error(self):
-        stack = ds.get_needle_data(aligned=True)
-        rec_stack, error = stack.recon_error(
+    def test_sirt_error(self, aligned_full_stack):
+        rec_stack, error = aligned_full_stack.recon_error(
             128,
             iterations=2,
             constrain=True,
             cuda=False,
         )
         assert error.data.shape[0] == rec_stack.data.shape[0]
-        assert rec_stack.data.shape[1:] == (stack.data.shape[1], stack.data.shape[1])
+        assert rec_stack.data.shape[1:] == (
+            aligned_full_stack.data.shape[1],
+            aligned_full_stack.data.shape[1],
+        )
 
-    def test_sirt_error_no_slice(self):
-        stack = ds.get_needle_data(aligned=True)
-        rec_stack, error = stack.recon_error(
+    def test_sirt_error_no_slice(self, aligned_full_stack):
+        rec_stack, error = aligned_full_stack.recon_error(
             None,
             iterations=2,
             constrain=True,
             cuda=False,
         )
         assert error.data.shape[0] == rec_stack.data.shape[0]
-        assert rec_stack.data.shape[1:] == (stack.data.shape[1], stack.data.shape[1])
+        assert rec_stack.data.shape[1:] == (
+            aligned_full_stack.data.shape[1],
+            aligned_full_stack.data.shape[1],
+        )
 
-    def test_recon_error_no_tilts(self):
-        stack = ds.get_needle_data(aligned=True)
-        del stack.tilts
+    def test_recon_error_no_tilts(self, aligned_full_stack):
+        stack_no_tilts = aligned_full_stack.deepcopy()
+        del stack_no_tilts.tilts
         with pytest.raises(ValueError, match="Tilt angles not defined"):
-            stack.recon_error(None, iterations=2, constrain=True, cuda=False)
+            stack_no_tilts.recon_error(None, iterations=2, constrain=True, cuda=False)
 
-    def test_sirt_error_no_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        rec_stack, error = stack.recon_error(
+    def test_sirt_error_no_cuda(self, aligned_full_stack):
+        rec_stack, error = aligned_full_stack.recon_error(
             128,
             iterations=50,
             constrain=True,
             cuda=None,
         )
         assert error.data.shape[0] == rec_stack.data.shape[0]
-        assert rec_stack.data.shape[1:] == (stack.data.shape[1], stack.data.shape[1])
+        assert rec_stack.data.shape[1:] == (
+            aligned_full_stack.data.shape[1],
+            aligned_full_stack.data.shape[1],
+        )
 
     @patch("astra.use_cuda", new=lambda: False)
-    def test_recon_error_astra_detect_use_cuda_false(self):
-        stack = ds.get_needle_data(aligned=True)
-        rec_stack, error = stack.recon_error(
+    def test_recon_error_astra_detect_use_cuda_false(self, aligned_full_stack):
+        rec_stack, error = aligned_full_stack.recon_error(
             128,
             iterations=50,
             constrain=True,
             cuda=None,
         )
         assert error.data.shape[0] == rec_stack.data.shape[0]
-        assert rec_stack.data.shape[1:] == (stack.data.shape[1], stack.data.shape[1])
+        assert rec_stack.data.shape[1:] == (
+            aligned_full_stack.data.shape[1],
+            aligned_full_stack.data.shape[1],
+        )
 
-    def test_sart_error(self):
-        stack = ds.get_needle_data(aligned=True)
-        rec_stack, error = stack.recon_error(
+    def test_sart_error(self, aligned_full_stack):
+        rec_stack, error = aligned_full_stack.recon_error(
             128,
             algorithm="SART",
             iterations=2,
@@ -1237,11 +1239,13 @@ class TestErrorPlots:
             cuda=False,
         )
         assert error.data.shape[0] == rec_stack.data.shape[0]
-        assert rec_stack.data.shape[1:] == (stack.data.shape[1], stack.data.shape[1])
+        assert rec_stack.data.shape[1:] == (
+            aligned_full_stack.data.shape[1],
+            aligned_full_stack.data.shape[1],
+        )
 
-    def test_sart_error_no_slice(self):
-        stack = ds.get_needle_data(aligned=True)
-        rec_stack, error = stack.recon_error(
+    def test_sart_error_no_slice(self, aligned_full_stack):
+        rec_stack, error = aligned_full_stack.recon_error(
             None,
             algorithm="SART",
             iterations=2,
@@ -1249,11 +1253,13 @@ class TestErrorPlots:
             cuda=False,
         )
         assert error.data.shape[0] == rec_stack.data.shape[0]
-        assert rec_stack.data.shape[1:] == (stack.data.shape[1], stack.data.shape[1])
+        assert rec_stack.data.shape[1:] == (
+            aligned_full_stack.data.shape[1],
+            aligned_full_stack.data.shape[1],
+        )
 
-    def test_sart_error_no_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        rec_stack, error = stack.recon_error(
+    def test_sart_error_no_cuda(self, aligned_full_stack):
+        rec_stack, error = aligned_full_stack.recon_error(
             128,
             algorithm="SART",
             iterations=50,
@@ -1261,32 +1267,31 @@ class TestErrorPlots:
             cuda=None,
         )
         assert error.data.shape[0] == rec_stack.data.shape[0]
-        assert rec_stack.data.shape[1:] == (stack.data.shape[1], stack.data.shape[1])
+        assert rec_stack.data.shape[1:] == (
+            aligned_full_stack.data.shape[1],
+            aligned_full_stack.data.shape[1],
+        )
 
 
 class TestTiltAlign:
     """Test tilt alignment of a TomoStack."""
 
-    def test_tilt_align_com_axis_zero(self):
-        stack = ds.get_needle_data(aligned=True)
+    def test_tilt_align_com_axis_zero(self, aligned_full_stack):
         com_tilt_aligner = TiltCOMAligner(
-            stack,
+            aligned_full_stack,
             slices=np.array([64, 100, 114]),
         )
         ali = com_tilt_aligner.align_tilt_axis()
         assert isinstance(ali, TomoStack)
 
-    def test_tilt_align_maximage(self):
-        stack = ds.get_needle_data(aligned=True)
-        stack = stack.inav[0:10]
+    def test_tilt_align_maximage(self, aligned_short_stack):
         maximage_tilt_aligner = TiltMaxImageAligner(
-            stack,
+            aligned_short_stack,
         )
         ali = maximage_tilt_aligner.align_tilt_axis()
         assert isinstance(ali, TomoStack)
 
-    def test_tilt_align_unknown_method(self):
-        stack = ds.get_needle_data(aligned=True)
+    def test_tilt_align_unknown_method(self, aligned_short_stack):
         bad_method = "UNKNOWN"
         with pytest.raises(
             ValueError,
@@ -1295,29 +1300,25 @@ class TestTiltAlign:
                 'Must be one of ["CoM" or "MaxImage"]',
             ),
         ):
-            stack.tilt_align(bad_method)  # pyright: ignore[reportArgumentType]
+            aligned_short_stack.tilt_align(bad_method)  # pyright: ignore[reportArgumentType]
 
 
 class TestTransStack:
     """Test translation of a TomoStack."""
 
-    def test_test_trans_stack_linear(self):
-        stack = ds.get_needle_data(aligned=True)
-        shifted = stack.trans_stack(1, 1, 1, "linear")
+    def test_test_trans_stack_linear(self, aligned_full_stack):
+        shifted = aligned_full_stack.trans_stack(1, 1, 1, "linear")
         assert isinstance(shifted, TomoStack)
 
-    def test_test_trans_stack_nearest(self):
-        stack = ds.get_needle_data(aligned=True)
-        shifted = stack.trans_stack(1, 1, 1, "nearest")
+    def test_test_trans_stack_nearest(self, aligned_full_stack):
+        shifted = aligned_full_stack.trans_stack(1, 1, 1, "nearest")
         assert isinstance(shifted, TomoStack)
 
-    def test_test_trans_stack_cubic(self):
-        stack = ds.get_needle_data(aligned=True)
-        shifted = stack.trans_stack(1, 1, 1, "cubic")
+    def test_test_trans_stack_cubic(self, aligned_full_stack):
+        shifted = aligned_full_stack.trans_stack(1, 1, 1, "cubic")
         assert isinstance(shifted, TomoStack)
 
-    def test_test_trans_stack_unknown(self):
-        stack = ds.get_needle_data(aligned=True)
+    def test_test_trans_stack_unknown(self, aligned_full_stack):
         bad_method = "UNKNOWN"
         with pytest.raises(
             ValueError,
@@ -1326,7 +1327,7 @@ class TestTransStack:
                 '["linear", "cubic", "nearest", or "none"].',
             ),
         ):
-            stack.trans_stack(
+            aligned_full_stack.trans_stack(
                 1,
                 1,
                 1,
@@ -1337,93 +1338,81 @@ class TestTransStack:
 class TestReconstruct:
     """Test reconstruction of a TomoStack."""
 
-    def test_cuda_detect(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[:, 120:121].deepcopy()
-        rec = slices.reconstruct("FBP", cuda=None)
+    def test_cuda_detect(self, aligned_short_stack):
+        rec = aligned_short_stack.reconstruct("FBP", cuda=None)
         assert isinstance(rec, RecStack)
 
     @patch("astra.use_cuda", new=lambda: False)
-    def test_astra_detect_use_cuda_false(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[:, 120:121].deepcopy()
-        rec = slices.reconstruct("FBP", cuda=None)
+    def test_astra_detect_use_cuda_false(self, aligned_short_stack):
+        rec = aligned_short_stack.reconstruct("FBP", cuda=None)
         assert isinstance(rec, RecStack)
 
-    def test_reconstruct_dart_no_gray_levels(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[:, 120:121].deepcopy()
+    def test_reconstruct_dart_no_gray_levels(self, aligned_short_stack):
         with pytest.raises(ValueError, match="gray_levels must be provided for DART"):
-            slices.reconstruct("DART", gray_levels=None)
+            aligned_short_stack.reconstruct("DART", gray_levels=None)
 
-    def test_reconstruct_dart_gray_levels_bad_type(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[:, 120:121].deepcopy()
+    def test_reconstruct_dart_gray_levels_bad_type(self, aligned_short_stack):
         with pytest.raises(
             ValueError,
             match=re.escape("Unknown type (<class 'str'>) for gray_levels"),
         ):
-            slices.reconstruct("DART", gray_levels="bad_type")  # type: ignore
+            aligned_short_stack.reconstruct("DART", gray_levels="bad_type")  # type: ignore
 
-    def test_reconstruct_dart_dart_iterations_none(self, caplog):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[:, 120:121].deepcopy()
-        gray_levels = [0.0, slices.data.max() / 2, slices.data.max()]
-        slices.reconstruct("DART", dart_iterations=None, gray_levels=gray_levels)
+    def test_reconstruct_dart_dart_iterations_none(self, caplog, aligned_short_stack):
+        gray_levels = [
+            0.0,
+            aligned_short_stack.data.max() / 2,
+            aligned_short_stack.data.max(),
+        ]
+        aligned_short_stack.reconstruct(
+            "DART",
+            dart_iterations=None,
+            gray_levels=gray_levels,
+        )
         assert "Using default number of DART iterations (5)" in caplog.text
 
 
 class TestManualAlign:
     """Test manual alignment of a TomoStack."""
 
-    def test_manual_align_positive_x(self):
-        stack = ds.get_needle_data(aligned=True)
-        shifted = stack.manual_align(128, xshift=10)
+    def test_manual_align_positive_x(self, short_stack):
+        shifted = short_stack.manual_align(2, xshift=10)
         assert isinstance(shifted, TomoStack)
 
-    def test_manual_align_negative_x(self):
-        stack = ds.get_needle_data(aligned=True)
-        shifted = stack.manual_align(128, xshift=-10)
+    def test_manual_align_negative_x(self, short_stack):
+        shifted = short_stack.manual_align(2, xshift=-10)
         assert isinstance(shifted, TomoStack)
 
-    def test_manual_align_positive_y(self):
-        stack = ds.get_needle_data(aligned=True)
-        shifted = stack.manual_align(128, yshift=10)
+    def test_manual_align_positive_y(self, short_stack):
+        shifted = short_stack.manual_align(2, yshift=10)
         assert isinstance(shifted, TomoStack)
 
-    def test_manual_align_negative_y(self):
-        stack = ds.get_needle_data(aligned=True)
-        shifted = stack.manual_align(128, yshift=-10)
+    def test_manual_align_negative_y(self, short_stack):
+        shifted = short_stack.manual_align(2, yshift=-10)
         assert isinstance(shifted, TomoStack)
 
-    def test_manual_align_negative_y_positive_x(self):
-        stack = ds.get_needle_data(aligned=True)
-        shifted = stack.manual_align(128, yshift=-10, xshift=10)
+    def test_manual_align_negative_y_positive_x(self, short_stack):
+        shifted = short_stack.manual_align(2, yshift=-10, xshift=10)
         assert isinstance(shifted, TomoStack)
 
-    def test_manual_align_negative_x_positive_y(self):
-        stack = ds.get_needle_data(aligned=True)
-        shifted = stack.manual_align(128, yshift=10, xshift=-10)
+    def test_manual_align_negative_x_positive_y(self, short_stack):
+        shifted = short_stack.manual_align(2, yshift=10, xshift=-10)
         assert isinstance(shifted, TomoStack)
 
-    def test_manual_align_negative_y_negative_x(self):
-        stack = ds.get_needle_data(aligned=True)
-        shifted = stack.manual_align(128, yshift=-10, xshift=-10)
+    def test_manual_align_negative_y_negative_x(self, short_stack):
+        shifted = short_stack.manual_align(2, yshift=-10, xshift=-10)
         assert isinstance(shifted, TomoStack)
 
-    def test_manual_align_positive_y_positive_x(self):
-        stack = ds.get_needle_data(aligned=True)
-        shifted = stack.manual_align(128, yshift=10, xshift=10)
+    def test_manual_align_positive_y_positive_x(self, short_stack):
+        shifted = short_stack.manual_align(2, yshift=10, xshift=10)
         assert isinstance(shifted, TomoStack)
 
-    def test_manual_align_no_shifts(self):
-        stack = ds.get_needle_data(aligned=True)
-        shifted = stack.manual_align(128)
+    def test_manual_align_no_shifts(self, short_stack):
+        shifted = short_stack.manual_align(2)
         assert isinstance(shifted, TomoStack)
 
-    def test_manual_align_with_display(self):
-        stack = ds.get_needle_data(aligned=True)
-        shifted = stack.manual_align(64, display=True)
+    def test_manual_align_with_display(self, short_stack):
+        shifted = short_stack.manual_align(2, yshift=10, xshift=-10, display=True)
         assert isinstance(shifted, TomoStack)
 
 

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -60,6 +60,13 @@ def aligned_full_stack():
     return s
 
 
+@pytest.fixture(scope="module")
+def multiframe_stack():
+    """Create multiframe stack."""
+    s = load_serialem_multiframe_data()
+    return s
+
+
 def _set_tomo_metadata(s: Signal2D) -> Signal2D:
     tomo_metadata = {
         "cropped": False,
@@ -88,63 +95,56 @@ class TestCommonStack:
         ):
             CommonStack(np.random.rand(10, 100, 100))
 
-    def test_slicing(self):
-        s = ds.get_needle_data()
-        s2 = s.inav[:5]
-        assert s2.data.shape == (5, 256, 256)
-        assert s2.shifts.data.shape == (5, 2)
-        assert s2.tilts.data.shape == (5, 1)
+    def test_slicing(self, short_stack):
+        assert short_stack.data.shape == (5, 256, 256)
+        assert short_stack.shifts.data.shape == (5, 2)
+        assert short_stack.tilts.data.shape == (5, 1)
 
-    def test_plot(self):
-        s = ds.get_needle_data()
-        s.plot()
+    def test_plot(self, short_stack):
+        short_stack.plot()
         f = plt.gcf()
         plt.close(f)
 
-    def test_save(self, tmp_path):
-        s = ds.get_needle_data()
+    def test_save(self, tmp_path, short_stack):
         fname = tmp_path / "save_test.hspy"
-        s.save(fname, file_format="HSPY")
+        short_stack.save(fname, file_format="HSPY")
         with h5py.File(fname, "r") as h5:
             data = h5.get("/Experiments/__unnamed__/data")
-            assert data.shape == (77, 256, 256)  # type: ignore
+            assert data.shape == (5, 256, 256)  # type: ignore
             tilts = h5.get("/Experiments/__unnamed__/metadata/Tomography/_sig_tilts")
-            assert tilts.get("data").shape == (77, 1)  # type: ignore
+            assert tilts.get("data").shape == (5, 1)  # type: ignore
             shifts = h5.get("/Experiments/__unnamed__/metadata/Tomography/_sig_shifts")
-            assert shifts.get("data").shape == (77, 2)  # type: ignore
+            assert shifts.get("data").shape == (5, 2)  # type: ignore
 
-    def test_save_raw(self, tmp_path):
+    def test_save_raw(self, tmp_path, short_stack):
         os.chdir(tmp_path)
-        s = ds.get_needle_data()
-        fname = s.save_raw()
+        fname = short_stack.save_raw()
         hs_s = hs_load(fname)
         assert isinstance(hs_s, Signal2D)
         assert isinstance(fname, Path)
         assert fname.exists()
 
-    def test_save_raw_with_fname(self, tmp_path):
-        s = ds.get_needle_data()
+    def test_save_raw_with_fname(self, tmp_path, short_stack):
         output_file = tmp_path / "test.rpl"
-        fname = s.save_raw(filename=output_file)
+        fname = short_stack.save_raw(filename=output_file)
         hs_s = hs_load(fname)
         assert isinstance(hs_s, Signal2D)
         assert isinstance(fname, Path)
         assert fname.exists()
-        assert fname == output_file.parent / "test_77x256x256_float32.rpl"
+        assert fname == output_file.parent / "test_5x256x256_float32.rpl"
 
-    def test_save_raw_with_fname_str(self, tmp_path):
-        s = ds.get_needle_data()
+    def test_save_raw_with_fname_str(self, tmp_path, short_stack):
         output_file = tmp_path / "test.rpl"
         output_file_str = str(output_file)
-        fname = s.save_raw(filename=output_file_str)
+        fname = short_stack.save_raw(filename=output_file_str)
         hs_s = hs_load(fname)
         assert isinstance(hs_s, Signal2D)
         assert isinstance(fname, Path)
         assert fname.exists()
-        assert fname == output_file.parent / "test_77x256x256_float32.rpl"
+        assert fname == output_file.parent / "test_5x256x256_float32.rpl"
 
-    def test_print_stats(self, capsys):
-        ds.get_needle_data().stats()
+    def test_print_stats(self, capsys, full_stack):
+        full_stack.stats()
         captured = capsys.readouterr()
         assert captured.out == "Mean: 4259.6\nStd: 11485.53\nMax: 64233.0\nMin: 0.0\n\n"
 
@@ -153,7 +153,7 @@ class TestTomoStack:
     """Test creation of a TomoStack."""
 
     def test_tomostack_create_by_signal(self):
-        s = hs.signals.Signal2D(np.random.random([10, 100, 100]))
+        s = hs.signals.Signal2D(np.random.random([5, 100, 100]))
         stack = TomoStack(s)
         assert isinstance(stack, TomoStack)
         assert hasattr(stack, "tilts")
@@ -162,7 +162,7 @@ class TestTomoStack:
         assert stack.metadata.get_item("Tomography.yshift") == 0
 
     def test_tomostack_create_by_signal_with_existing_tomometa(self):
-        s = hs.signals.Signal2D(np.random.random([10, 100, 100]))
+        s = hs.signals.Signal2D(np.random.random([5, 100, 100]))
         s = _set_tomo_metadata(s)
         s.metadata.set_item("General.title", "Test title")
         stack = TomoStack(s)
@@ -176,7 +176,7 @@ class TestTomoStack:
         assert stack.metadata.get_item("General.title") == "Test title"
 
     def test_tomostack_create_by_signal_with_tomometa_dict(self):
-        s = hs.signals.Signal2D(np.random.random([10, 100, 100]))
+        s = hs.signals.Signal2D(np.random.random([5, 100, 100]))
         meta_dict = {
             "General": {"title": "test signal"},
             "Tomography": {
@@ -197,7 +197,7 @@ class TestTomoStack:
         assert stack.metadata.get_item("General.title") == "test signal"
 
     def test_tomostack_create_by_signal_without_tomometa_dict(self):
-        s = hs.signals.Signal2D(np.random.random([10, 100, 100]))
+        s = hs.signals.Signal2D(np.random.random([5, 100, 100]))
         meta_dict = {
             "General": {"title": "test signal"},
         }
@@ -212,7 +212,7 @@ class TestTomoStack:
         assert stack.metadata.get_item("General.title") == "test signal"
 
     def test_tomostack_create_by_signal_original_metadata(self):
-        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([10, 100, 100])))
+        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([5, 100, 100])))
         s.metadata.set_item("General.title", "original_metadata test")
         s.original_metadata.set_item("Level1.level2", "the value")
         stack = TomoStack(s)
@@ -220,7 +220,7 @@ class TestTomoStack:
         assert stack.original_metadata.get_item("Level1.level2") == "the value"
 
     def test_tomostack_create_by_signal_original_metadata_arg(self):
-        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([10, 100, 100])))
+        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([5, 100, 100])))
         s.metadata.set_item("General.title", "original_metadata test")
         s.original_metadata.set_item("Level1.level2", "the value")
         stack = TomoStack(s, original_metadata={"A1": {"B1": "C", "B2": "C2"}})
@@ -230,7 +230,7 @@ class TestTomoStack:
         assert stack.original_metadata.get_item("A1.B2") == "C2"
 
     def test_tomostack_create_by_signal_axes(self):
-        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([10, 100, 100])))
+        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([5, 100, 100])))
         s.axes_manager[0].name = "Test nav"  # type: ignore
         s.axes_manager[0].units = "Nav units"  # type: ignore
         stack = TomoStack(s)
@@ -238,14 +238,14 @@ class TestTomoStack:
         assert stack.axes_manager[0].units == "Nav units"  # type: ignore
 
     def test_tomostack_create_by_signal_axes_list_arg(self):
-        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([10, 100, 100])))
+        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([5, 100, 100])))
         ax_list = [
             {
                 "_type": "UniformDataAxis",
                 "name": "nav_from_list",
                 "units": "test units",
                 "navigate": True,
-                "size": 10,
+                "size": 5,
                 "scale": 1.0,
                 "offset": 1,
             },
@@ -278,9 +278,9 @@ class TestTomoStack:
         assert stack.axes_manager[-1].scale == 0.123  # type: ignore
 
     def test_tomostack_create_by_signal_undefined_axes(self):
-        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([10, 100, 100])))
+        s = cast("Signal2D", hs.signals.Signal2D(np.random.random([5, 100, 100])))
         axes = [
-            {"size": 10, "name": "Axis0", "units": ""},
+            {"size": 5, "name": "Axis0", "units": ""},
             {"size": 100, "name": "Axis1", "units": ""},
             {"size": 100, "name": "Axis2", "units": ""},
         ]
@@ -289,7 +289,7 @@ class TestTomoStack:
         assert stack.axes_manager[0].units == "degrees"  # type: ignore
 
     def test_tomostack_create_by_array_multiframe(self):
-        n = np.random.random([20, 5, 110, 120])
+        n = np.random.random([5, 2, 110, 120])
         stack = TomoStack(n)
         ax0, ax1, ax2, ax3 = (cast("Uda", stack.axes_manager[i]) for i in range(4))
         assert ax0.name == "Frames"
@@ -300,8 +300,8 @@ class TestTomoStack:
         assert ax1.units == "degrees"
         assert ax2.units == "pixels"
         assert ax3.units == "pixels"
-        assert ax0.size == 5
-        assert ax1.size == 20
+        assert ax0.size == 2
+        assert ax1.size == 5
         assert ax2.size == 120
         assert ax3.size == 110
 
@@ -316,61 +316,58 @@ class TestTomoStack:
         ):
             TomoStack(n)
 
-    def test_deepcopy(self):
-        s = ds.get_needle_data()
-        s2 = s.deepcopy()
-        assert np.all(s.data == s2.data)
-        assert np.all(s.tilts.data == s2.tilts.data)
-        assert np.all(s.shifts.data == s2.shifts.data)
-        assert s is not s2
-        assert s.data is not s2.data
-        assert s.tilts.data is not s2.tilts.data
-        assert s.shifts.data is not s2.shifts.data
+    def test_deepcopy(self, short_stack):
+        s2 = short_stack.deepcopy()
+        assert np.all(short_stack.data == s2.data)
+        assert np.all(short_stack.tilts.data == s2.tilts.data)
+        assert np.all(short_stack.shifts.data == s2.shifts.data)
+        assert short_stack is not s2
+        assert short_stack.data is not s2.data
+        assert short_stack.tilts.data is not s2.tilts.data
+        assert short_stack.shifts.data is not s2.shifts.data
         np.testing.assert_equal(
-            s.metadata.as_dictionary(),
+            short_stack.metadata.as_dictionary(),
             s2.metadata.as_dictionary(),
         )
 
-    def test_copy(self):
-        s = ds.get_needle_data()
-        s2 = s.copy()
-        assert np.all(s.data == s2.data)
-        assert np.all(s.tilts.data == s2.tilts.data)
-        assert np.all(s.shifts.data == s2.shifts.data)
-        assert s is not s2
-        assert s.data is s2.data
-        assert s.tilts.data is s2.tilts.data
-        assert s.shifts.data is s2.shifts.data
+    def test_copy(self, short_stack):
+        s2 = short_stack.copy()
+        assert np.all(short_stack.data == s2.data)
+        assert np.all(short_stack.tilts.data == s2.tilts.data)
+        assert np.all(short_stack.shifts.data == s2.shifts.data)
+        assert short_stack is not s2
+        assert short_stack.data is s2.data
+        assert short_stack.tilts.data is s2.tilts.data
+        assert short_stack.shifts.data is s2.shifts.data
         np.testing.assert_equal(
-            s.metadata.as_dictionary(),
+            short_stack.metadata.as_dictionary(),
             s2.metadata.as_dictionary(),
         )
 
-    def test_remove_projections(self):
-        s = ds.get_needle_data(aligned=True)
-        s_new = s.remove_projections([0, 5, 10, 15, 20])
-        # original shape is (77, 256, 256)
-        assert s_new.data.shape == (72, 256, 256)
-        assert s_new.tilts.data.shape == (72, 1)
-        assert s_new.shifts.data.shape == (72, 2)
-        for t in [-76, -66, -56, -46, -36]:
+    def test_remove_projections(self, short_stack):
+        remove_indices = [0, 1, 3]
+        tilts_to_remove = [short_stack.tilts.data[i] for i in remove_indices]
+        s_new = short_stack.remove_projections(remove_indices)
+        # original shape is (5, 256, 256)
+        assert s_new.data.shape == (2, 256, 256)
+        assert s_new.tilts.data.shape == (2, 1)
+        assert s_new.shifts.data.shape == (2, 2)
+        for t in tilts_to_remove:
             assert t not in s_new.tilts.data
 
-    def test_remove_projections_none(self):
-        s = ds.get_needle_data(aligned=True)
+    def test_remove_projections_none(self, short_stack):
         with pytest.raises(ValueError, match="No projections provided"):
-            s.remove_projections(None)
+            short_stack.remove_projections(None)
 
-    def test_plot_sinos(self):
-        s = ds.get_needle_data(aligned=True)
-        s.plot_sinos()
+    def test_plot_sinos(self, short_stack):
+        short_stack.plot_sinos()
         f = plt.gcf()
         xlim = f.axes[0].get_xlim()
         ylim = f.axes[0].get_ylim()
         assert xlim[0] == pytest.approx(-1.68)
         assert xlim[1] == pytest.approx(858.48)
-        assert ylim[0] == pytest.approx(77)
-        assert ylim[1] == pytest.approx(-77)
+        assert ylim[0] == pytest.approx(4.5)
+        assert ylim[1] == pytest.approx(-0.5)
         assert f.axes[0].title.get_text() == " Signal"
         assert f.axes[0].get_xlabel() == "y axis (nm)"
         assert f.axes[0].get_ylabel() == "Projections axis (degrees)"
@@ -452,31 +449,50 @@ class TestProperties:
         ):
             TomoShifts(n)
 
-    def test_tilt_setter(self):
-        s = ds.get_needle_data()
-        s.tilts = np.random.rand(77, 1)
-        assert s.tilts.metadata.get_item("General.title") == "Image tilt values"
-        assert s.tilts.axes_manager.shape == (77, 1)
-        assert s.tilts.data.shape == (77, 1)
+    def test_tilt_setter(self, full_stack):
+        full_stack_random_tilts = full_stack.deepcopy()
+        full_stack_random_tilts.tilts = np.random.rand(77, 1)
+        assert (
+            full_stack_random_tilts.tilts.metadata.get_item("General.title")
+            == "Image tilt values"
+        )
+        assert full_stack_random_tilts.tilts.axes_manager.shape == (77, 1)
+        assert full_stack_random_tilts.tilts.data.shape == (77, 1)
 
-    def test_tilt_setter_1d_array(self):
-        s = ds.get_needle_data()
-        s.tilts = np.random.rand(77)  # should be coerced to (77, 1)
+    def test_tilt_setter_1d_array(self, full_stack):
+        full_stack_random_tilts = full_stack.deepcopy()
+        full_stack_random_tilts.tilts = np.random.rand(
+            77
+        )  # should be coerced to (77, 1)
 
-        assert s.tilts.metadata.get_item("General.title") == "Image tilt values"
-        assert s.tilts.axes_manager.shape == (77, 1)
-        assert s.tilts.data.shape == (77, 1)
-        assert s.tilts.axes_manager[-1].name == "Tilt values"  # type: ignore
-        assert s.tilts.axes_manager[-1].units == "degrees"  # type: ignore
+        assert (
+            full_stack_random_tilts.tilts.metadata.get_item("General.title")
+            == "Image tilt values"
+        )
+        assert full_stack_random_tilts.tilts.axes_manager.shape == (77, 1)
+        assert full_stack_random_tilts.tilts.data.shape == (77, 1)
+        assert full_stack_random_tilts.tilts.axes_manager[-1].name == "Tilt values"  # type: ignore
+        assert full_stack_random_tilts.tilts.axes_manager[-1].units == "degrees"  # type: ignore
 
         # check that tilt axes info matches signal
-        assert s.tilts.axes_manager[0].name == s.axes_manager[0].name  # type: ignore
-        assert s.tilts.axes_manager[0].units == s.axes_manager[0].units  # type: ignore
-        assert s.tilts.axes_manager[0].scale == s.axes_manager[0].scale  # type: ignore
-        assert s.tilts.axes_manager[0].offset == s.axes_manager[0].offset  # type: ignore
+        assert (
+            full_stack_random_tilts.tilts.axes_manager[0].name
+            == full_stack.axes_manager[0].name
+        )  # type: ignore
+        assert (
+            full_stack_random_tilts.tilts.axes_manager[0].units
+            == full_stack.axes_manager[0].units
+        )  # type: ignore
+        assert (
+            full_stack_random_tilts.tilts.axes_manager[0].scale
+            == full_stack.axes_manager[0].scale
+        )  # type: ignore
+        assert (
+            full_stack_random_tilts.tilts.axes_manager[0].offset
+            == full_stack.axes_manager[0].offset
+        )  # type: ignore
 
-    def test_tilt_setter_bad_dims(self):
-        s = ds.get_needle_data()
+    def test_tilt_setter_bad_dims(self, full_stack):
         with pytest.raises(
             ValueError,
             match=re.escape(
@@ -484,18 +500,20 @@ class TestProperties:
                 "size of the stack (was (20, 1))",
             ),
         ):
-            s.tilts = np.random.rand(20, 1)
+            full_stack.tilts = np.random.rand(20, 1)
 
-    def test_tilt_setter_tomotilt(self):
-        s = ds.get_needle_data()
+    def test_tilt_setter_tomotilt(self, full_stack):
+        full_stack_random_tilts = full_stack.deepcopy()
         n = np.random.rand(77, 1)
         tilts = TomoTilts(n)
         assert tilts.metadata.get_item("General.title") == ""
-        s.tilts = tilts  # title should be set since it was empty
-        assert s.tilts.metadata.get_item("General.title") == "Image tilt values"
+        full_stack_random_tilts.tilts = tilts  # title should be set since it was empty
+        assert (
+            full_stack_random_tilts.tilts.metadata.get_item("General.title")
+            == "Image tilt values"
+        )
 
-    def test_tilt_setter_tomotilt_bad_dims(self):
-        s = ds.get_needle_data()
+    def test_tilt_setter_tomotilt_bad_dims(self, full_stack):
         n = np.random.rand(20, 1)
         tilts = TomoTilts(n)
         assert tilts.metadata.get_item("General.title") == ""
@@ -506,25 +524,42 @@ class TestProperties:
                 "of the stack (was (20, 1))",
             ),
         ):
-            s.tilts = tilts
+            full_stack.tilts = tilts
 
-    def test_shift_setter(self):
-        s = ds.get_needle_data()
-        s.shifts = np.random.rand(77, 2)
-        assert s.shifts.metadata.get_item("General.title") == "Image shift values"
-        assert s.shifts.axes_manager.shape == (77, 2)
-        assert s.shifts.data.shape == (77, 2)
-        assert s.shifts.axes_manager[-1].name == "Shift values (x/y)"  # type: ignore
-        assert s.shifts.axes_manager[-1].units == "pixels"  # type: ignore
+    def test_shift_setter(self, full_stack):
+        full_stack_random_shifts = full_stack.deepcopy()
+        full_stack_random_shifts.shifts = np.random.rand(77, 2)
+        assert (
+            full_stack_random_shifts.shifts.metadata.get_item("General.title")
+            == "Image shift values"
+        )
+        assert full_stack_random_shifts.shifts.axes_manager.shape == (77, 2)
+        assert full_stack_random_shifts.shifts.data.shape == (77, 2)
+        assert (
+            full_stack_random_shifts.shifts.axes_manager[-1].name
+            == "Shift values (x/y)"
+        )  # type: ignore
+        assert full_stack_random_shifts.shifts.axes_manager[-1].units == "pixels"  # type: ignore
 
         # check that tilt axes info matches signal
-        assert s.shifts.axes_manager[0].name == s.axes_manager[0].name  # type: ignore
-        assert s.shifts.axes_manager[0].units == s.axes_manager[0].units  # type: ignore
-        assert s.shifts.axes_manager[0].scale == s.axes_manager[0].scale  # type: ignore
-        assert s.shifts.axes_manager[0].offset == s.axes_manager[0].offset  # type: ignore
+        assert (
+            full_stack_random_shifts.shifts.axes_manager[0].name
+            == full_stack_random_shifts.axes_manager[0].name
+        )  # type: ignore
+        assert (
+            full_stack_random_shifts.shifts.axes_manager[0].units
+            == full_stack_random_shifts.axes_manager[0].units
+        )  # type: ignore
+        assert (
+            full_stack_random_shifts.shifts.axes_manager[0].scale
+            == full_stack.axes_manager[0].scale
+        )  # type: ignore
+        assert (
+            full_stack.shifts.axes_manager[0].offset
+            == full_stack_random_shifts.axes_manager[0].offset
+        )  # type: ignore
 
-    def test_shift_setter_bad_dims(self):
-        s = ds.get_needle_data()
+    def test_shift_setter_bad_dims(self, full_stack):
         with pytest.raises(
             ValueError,
             match=re.escape(
@@ -532,7 +567,7 @@ class TestProperties:
                 "size of the stack (was (77,))",
             ),
         ):
-            s.shifts = np.random.rand(77)
+            full_stack.shifts = np.random.rand(77)
         with pytest.raises(
             ValueError,
             match=re.escape(
@@ -540,18 +575,18 @@ class TestProperties:
                 "size of the stack (was (20, 1, 5))",
             ),
         ):
-            s.shifts = np.random.rand(20, 1, 5)
+            full_stack.shifts = np.random.rand(20, 1, 5)
 
-    def test_shift_setter_tomoshift(self):
-        s = ds.get_needle_data()
+    def test_shift_setter_tomoshift(self, full_stack):
         n = np.random.rand(77, 2)
         shifts = TomoShifts(n)
         assert shifts.metadata.get_item("General.title") == ""
-        s.shifts = shifts  # title should be set since it was empty
-        assert s.shifts.metadata.get_item("General.title") == "Image shift values"
+        full_stack.shifts = shifts  # title should be set since it was empty
+        assert (
+            full_stack.shifts.metadata.get_item("General.title") == "Image shift values"
+        )
 
-    def test_shift_setter_tomoshift_bad_dims(self):
-        s = ds.get_needle_data()
+    def test_shift_setter_tomoshift_bad_dims(self, full_stack):
         n = np.random.rand(20, 2)
         shifts = TomoShifts(n)
         assert shifts.metadata.get_item("General.title") == ""
@@ -562,40 +597,43 @@ class TestProperties:
                 "of the stack (was (20, 2))",
             ),
         ):
-            s.shifts = shifts
+            full_stack.shifts = shifts
 
-    def test_multiframe_tilt_setter(self):
-        s = load_serialem_multiframe_data()
-        assert s.axes_manager.shape == (2, 3, 1024, 1024)
-        assert s.data.shape == (3, 2, 1024, 1024)
-        assert s.tilts.axes_manager.shape == (2, 3, 1)
-        assert s.tilts.data.shape == (3, 2, 1)
+    def test_multiframe_tilt_setter(self, multiframe_stack):
+        assert multiframe_stack.axes_manager.shape == (2, 3, 1024, 1024)
+        assert multiframe_stack.data.shape == (3, 2, 1024, 1024)
+        assert multiframe_stack.tilts.axes_manager.shape == (2, 3, 1)
+        assert multiframe_stack.tilts.data.shape == (3, 2, 1)
 
         n = np.random.rand(3, 2, 1)
-        s.tilts = n
-        assert s.tilts.axes_manager.shape == (2, 3, 1)
-        assert s.tilts.data.shape == (3, 2, 1)
-        assert s.tilts.metadata.get_item("General.title") == "Image tilt values"
+        multiframe_stack.tilts = n
+        assert multiframe_stack.tilts.axes_manager.shape == (2, 3, 1)
+        assert multiframe_stack.tilts.data.shape == (3, 2, 1)
+        assert (
+            multiframe_stack.tilts.metadata.get_item("General.title")
+            == "Image tilt values"
+        )
 
-    def test_multiframe_tilt_setter_2d(self):
-        s = load_serialem_multiframe_data()
-        assert s.axes_manager.shape == (2, 3, 1024, 1024)
-        assert s.data.shape == (3, 2, 1024, 1024)
-        assert s.tilts.axes_manager.shape == (2, 3, 1)
-        assert s.tilts.data.shape == (3, 2, 1)
+    def test_multiframe_tilt_setter_2d(self, multiframe_stack):
+        assert multiframe_stack.axes_manager.shape == (2, 3, 1024, 1024)
+        assert multiframe_stack.data.shape == (3, 2, 1024, 1024)
+        assert multiframe_stack.tilts.axes_manager.shape == (2, 3, 1)
+        assert multiframe_stack.tilts.data.shape == (3, 2, 1)
 
         n = np.random.rand(3, 2)
-        s.tilts = n
-        assert s.tilts.axes_manager.shape == (2, 3, 1)
-        assert s.tilts.data.shape == (3, 2, 1)
-        assert s.tilts.metadata.get_item("General.title") == "Image tilt values"
+        multiframe_stack.tilts = n
+        assert multiframe_stack.tilts.axes_manager.shape == (2, 3, 1)
+        assert multiframe_stack.tilts.data.shape == (3, 2, 1)
+        assert (
+            multiframe_stack.tilts.metadata.get_item("General.title")
+            == "Image tilt values"
+        )
 
-    def test_multiframe_tilt_setter_bad_dims(self):
-        s = load_serialem_multiframe_data()
-        assert s.axes_manager.shape == (2, 3, 1024, 1024)
-        assert s.data.shape == (3, 2, 1024, 1024)
-        assert s.tilts.axes_manager.shape == (2, 3, 1)
-        assert s.tilts.data.shape == (3, 2, 1)
+    def test_multiframe_tilt_setter_bad_dims(self, multiframe_stack):
+        assert multiframe_stack.axes_manager.shape == (2, 3, 1024, 1024)
+        assert multiframe_stack.data.shape == (3, 2, 1024, 1024)
+        assert multiframe_stack.tilts.axes_manager.shape == (2, 3, 1)
+        assert multiframe_stack.tilts.data.shape == (3, 2, 1)
 
         n = np.random.rand(2, 3, 1)
         with pytest.raises(
@@ -605,7 +643,7 @@ class TestProperties:
                 "of the stack (was (2, 3, 1))",
             ),
         ):
-            s.tilts = n
+            multiframe_stack.tilts = n
 
         n = np.random.rand(3, 2, 10)
         with pytest.raises(
@@ -615,27 +653,28 @@ class TestProperties:
                 "of the stack (was (3, 2, 10))",
             ),
         ):
-            s.tilts = n
+            multiframe_stack.tilts = n
 
-    def test_multiframe_shift__setter(self):
-        s = load_serialem_multiframe_data()
-        assert s.axes_manager.shape == (2, 3, 1024, 1024)
-        assert s.data.shape == (3, 2, 1024, 1024)
-        assert s.shifts.axes_manager.shape == (2, 3, 2)
-        assert s.shifts.data.shape == (3, 2, 2)
+    def test_multiframe_shift__setter(self, multiframe_stack):
+        assert multiframe_stack.axes_manager.shape == (2, 3, 1024, 1024)
+        assert multiframe_stack.data.shape == (3, 2, 1024, 1024)
+        assert multiframe_stack.shifts.axes_manager.shape == (2, 3, 2)
+        assert multiframe_stack.shifts.data.shape == (3, 2, 2)
 
         n = np.random.rand(3, 2, 2)
-        s.shifts = n
-        assert s.shifts.axes_manager.shape == (2, 3, 2)
-        assert s.shifts.data.shape == (3, 2, 2)
-        assert s.shifts.metadata.get_item("General.title") == "Image shift values"
+        multiframe_stack.shifts = n
+        assert multiframe_stack.shifts.axes_manager.shape == (2, 3, 2)
+        assert multiframe_stack.shifts.data.shape == (3, 2, 2)
+        assert (
+            multiframe_stack.shifts.metadata.get_item("General.title")
+            == "Image shift values"
+        )
 
-    def test_multiframe_shift__setter_bad_dims(self):
-        s = load_serialem_multiframe_data()
-        assert s.axes_manager.shape == (2, 3, 1024, 1024)
-        assert s.data.shape == (3, 2, 1024, 1024)
-        assert s.shifts.axes_manager.shape == (2, 3, 2)
-        assert s.shifts.data.shape == (3, 2, 2)
+    def test_multiframe_shift__setter_bad_dims(self, multiframe_stack):
+        assert multiframe_stack.axes_manager.shape == (2, 3, 1024, 1024)
+        assert multiframe_stack.data.shape == (3, 2, 1024, 1024)
+        assert multiframe_stack.shifts.axes_manager.shape == (2, 3, 2)
+        assert multiframe_stack.shifts.data.shape == (3, 2, 2)
 
         n = np.random.rand(2, 3, 2)
         with pytest.raises(
@@ -645,7 +684,7 @@ class TestProperties:
                 "of the stack (was (2, 3, 2))",
             ),
         ):
-            s.shifts = n
+            multiframe_stack.shifts = n
 
         n = np.random.rand(3, 2, 10)
         with pytest.raises(
@@ -655,21 +694,21 @@ class TestProperties:
                 "of the stack (was (3, 2, 10))",
             ),
         ):
-            s.shifts = n
+            multiframe_stack.shifts = n
 
-    def test_property_deleters(self):
-        s = ds.get_needle_data()
-
+    def test_property_deleters(self, full_stack):
         # tilts
-        assert np.all(s.tilts.data.squeeze() == np.arange(-76, 78, 2))
-        del s.tilts
-        assert np.all(s.tilts.data.squeeze() == np.zeros((77, 1)))
+        full_stack_no_tilts = full_stack.deepcopy()
+        assert np.all(full_stack.tilts.data.squeeze() == np.arange(-76, 78, 2))
+        del full_stack_no_tilts.tilts
+        assert np.all(full_stack_no_tilts.tilts.data.squeeze() == np.zeros((77, 1)))
 
         # shifts
-        s.shifts = np.random.rand(77, 2) + 2  # offset to ensure non-zero
-        assert np.all(s.shifts.data != np.zeros((77, 2)))
-        del s.shifts
-        assert np.all(s.shifts.data == np.zeros((77, 2)))
+        full_stack_no_shifts = full_stack.deepcopy()
+        full_stack.shifts = np.random.rand(77, 2) + 2  # offset to ensure non-zero
+        assert np.all(full_stack.shifts.data != np.zeros((77, 2)))
+        del full_stack_no_shifts.shifts
+        assert np.all(full_stack_no_shifts.shifts.data == np.zeros((77, 2)))
 
 
 class TestSlicers:

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -951,58 +951,44 @@ class TestExtractSinogram:
 class TestFiltering:
     """Test filtering of TomoStack data."""
 
-    def test_correlation_check(self):
-        stack = ds.get_needle_data()
-        fig = stack.test_correlation()
+    def test_correlation_check(self, short_stack):
+        fig = short_stack.test_correlation()
         assert isinstance(fig, Figure)
         assert len(fig.axes) == NUM_AXES_THREE
 
-    def test_image_filter_median(self):
-        stack = ds.get_needle_data()
-        filt = stack.inav[0:10].filter(method="median")
+    def test_image_filter_median(self, short_stack):
+        filt = short_stack.filter(method="median")
         assert (
             filt.axes_manager.navigation_shape
-            == stack.inav[0:10].axes_manager.navigation_shape
+            == short_stack.axes_manager.navigation_shape
         )
-        assert (
-            filt.axes_manager.signal_shape == stack.inav[0:10].axes_manager.signal_shape
-        )
+        assert filt.axes_manager.signal_shape == short_stack.axes_manager.signal_shape
 
-    def test_image_filter_sobel(self):
-        stack = ds.get_needle_data()
-        filt = stack.inav[0:10].filter(method="sobel")
+    def test_image_filter_sobel(self, short_stack):
+        filt = short_stack.filter(method="sobel")
         assert (
             filt.axes_manager.navigation_shape
-            == stack.inav[0:10].axes_manager.navigation_shape
+            == short_stack.axes_manager.navigation_shape
         )
-        assert (
-            filt.axes_manager.signal_shape == stack.inav[0:10].axes_manager.signal_shape
-        )
+        assert filt.axes_manager.signal_shape == short_stack.axes_manager.signal_shape
 
-    def test_image_filter_both(self):
-        stack = ds.get_needle_data()
-        filt = stack.inav[0:10].filter(method="both")
+    def test_image_filter_both(self, short_stack):
+        filt = short_stack.filter(method="both")
         assert (
             filt.axes_manager.navigation_shape
-            == stack.inav[0:10].axes_manager.navigation_shape
+            == short_stack.axes_manager.navigation_shape
         )
-        assert (
-            filt.axes_manager.signal_shape == stack.inav[0:10].axes_manager.signal_shape
-        )
+        assert filt.axes_manager.signal_shape == short_stack.axes_manager.signal_shape
 
-    def test_image_filter_bpf(self):
-        stack = ds.get_needle_data()
-        filt = stack.inav[0:10].filter(method="bpf")
+    def test_image_filter_bpf(self, short_stack):
+        filt = short_stack.filter(method="bpf")
         assert (
             filt.axes_manager.navigation_shape
-            == stack.inav[0:10].axes_manager.navigation_shape
+            == short_stack.axes_manager.navigation_shape
         )
-        assert (
-            filt.axes_manager.signal_shape == stack.inav[0:10].axes_manager.signal_shape
-        )
+        assert filt.axes_manager.signal_shape == short_stack.axes_manager.signal_shape
 
-    def test_image_filter_wrong_name(self):
-        stack = ds.get_needle_data()
+    def test_image_filter_wrong_name(self, short_stack):
         bad_name = "WRONG"
         with pytest.raises(
             ValueError,
@@ -1011,7 +997,7 @@ class TestFiltering:
                 'Must be one of ["median", "bpf", "both", or "sobel"]',
             ),
         ):
-            stack.inav[0:10].filter(method="WRONG")  # type: ignore
+            short_stack.filter(method="WRONG")  # type: ignore
 
 
 class TestOperations:

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -32,6 +32,34 @@ if TYPE_CHECKING:
 NUM_AXES_THREE = 3
 
 
+@pytest.fixture(scope="module")
+def short_stack():
+    """Load stack from test data and truncate to 5 images."""
+    return ds.get_needle_data().inav[0:5]
+
+
+@pytest.fixture(scope="module")
+def full_stack():
+    """Load stack from test data."""
+    return ds.get_needle_data()
+
+
+@pytest.fixture(scope="module")
+def aligned_short_stack():
+    """Create truncated and spatially registered stack from test data."""
+    s = ds.get_needle_data().inav[0:5]
+    s = s.stack_register("PC")
+    return s
+
+
+@pytest.fixture(scope="module")
+def aligned_full_stack():
+    """Create full spatially registered stack from test data."""
+    s = ds.get_needle_data()
+    s = s.stack_register("PC")
+    return s
+
+
 def _set_tomo_metadata(s: Signal2D) -> Signal2D:
     tomo_metadata = {
         "cropped": False,

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -1003,11 +1003,13 @@ class TestFiltering:
 class TestOperations:
     """Test various operations of a TomoStack."""
 
-    def test_stack_normalize(self):
-        stack = ds.get_needle_data()
-        norm = cast("TomoStack", stack.normalize())
-        assert norm.axes_manager.navigation_shape == stack.axes_manager.navigation_shape
-        assert norm.axes_manager.signal_shape == stack.axes_manager.signal_shape
+    def test_stack_normalize(self, short_stack):
+        norm = cast("TomoStack", short_stack.normalize())
+        assert (
+            norm.axes_manager.navigation_shape
+            == short_stack.axes_manager.navigation_shape
+        )
+        assert norm.axes_manager.signal_shape == short_stack.axes_manager.signal_shape
         assert norm.data.min() == 0.0
 
     def test_stack_invert(self):
@@ -1019,24 +1021,22 @@ class TestOperations:
         hist_inv, _ = np.histogram(invert.data)
         assert hist[0] > hist_inv[0]
 
-    def test_stack_stats(self, capsys):
-        stack = ds.get_needle_data()
-        stack.stats()
+    def test_stack_stats(self, capsys, short_stack):
+        short_stack.stats()
 
         # capture output stream to test print statements
         captured = capsys.readouterr()
         out = captured.out.split("\n")
 
-        assert out[0] == f"Mean: {stack.data.mean():.1f}"
-        assert out[1] == f"Std: {stack.data.std():.2f}"
-        assert out[2] == f"Max: {stack.data.max():.1f}"
-        assert out[3] == f"Min: {stack.data.min():.1f}"
+        assert out[0] == f"Mean: {short_stack.data.mean():.1f}"
+        assert out[1] == f"Std: {short_stack.data.std():.2f}"
+        assert out[2] == f"Max: {short_stack.data.max():.1f}"
+        assert out[3] == f"Min: {short_stack.data.min():.1f}"
 
-    def test_set_tilts(self):
-        stack = ds.get_needle_data()
+    def test_set_tilts(self, full_stack):
         start, increment = -50, 5
-        stack.set_tilts(start, increment)
-        ax = cast("Uda", stack.axes_manager[0])
+        full_stack.set_tilts(start, increment)
+        ax = cast("Uda", full_stack.axes_manager[0])
         assert ax.name == "Projections"
         assert ax.scale == increment
         assert ax.units == "degrees"
@@ -1045,13 +1045,13 @@ class TestOperations:
             ax.axis.all()
             == np.arange(
                 start,
-                stack.data.shape[0] * increment + start,
+                full_stack.data.shape[0] * increment + start,
                 increment,
             ).all()
         )
 
-    def test_set_tilts_no_metadata(self):
-        stack = ds.get_needle_data()
+    def test_set_tilts_no_metadata(self, full_stack):
+        stack = full_stack.deepcopy()
         del stack.metadata.Tomography  # pyright: ignore[reportAttributeAccessIssue]
         start, increment = -50, 5
         stack.set_tilts(start, increment)

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -143,11 +143,6 @@ class TestCommonStack:
         assert fname.exists()
         assert fname == output_file.parent / "test_5x256x256_float32.rpl"
 
-    def test_print_stats(self, capsys, full_stack):
-        full_stack.stats()
-        captured = capsys.readouterr()
-        assert captured.out == "Mean: 4259.6\nStd: 11485.53\nMax: 64233.0\nMin: 0.0\n\n"
-
 
 class TestTomoStack:
     """Test creation of a TomoStack."""

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -803,7 +803,7 @@ class TestSlicers:
         assert t4.axes_manager[1].name == "y"  # type: ignore
         assert t4.tilts.axes_manager.navigation_shape == ()
         assert t4.shifts.axes_manager.navigation_shape == ()
-        assert t4.tilts.data[0] == pytest.approx(-0.000488)
+        # assert t4.tilts.data[0] == pytest.approx(-0.000488)
 
     def test_single_pixel_nav_slicer(self, short_stack):
         t = short_stack.inav[3]
@@ -907,18 +907,18 @@ class TestExtractSinogram:
     """Test extract_sinogram method."""
 
     def test_extract_sinogram(self, full_stack):
-        sino = full_stack.extract_sinogram(300)
+        sino = full_stack.extract_sinogram(128)
         ax_0, ax_1 = cast("list[Uda]", [sino.axes_manager[i] for i in range(2)])
-        assert sino.axes_manager.shape == (600, 90)
+        assert sino.axes_manager.shape == (256, 77)
         assert sino.metadata.get_item("Signal.signal_type") == ""
         assert ax_0.name == "y"
         assert ax_1.name == "Projections"
-        assert sino.metadata.get_item("General.title") == "Sinogram at column 300"
+        assert sino.metadata.get_item("General.title") == "Sinogram at column 128"
 
     def test_extract_sinogram_float(self, full_stack):
         sino = full_stack.extract_sinogram(106.32)
         ax_0, ax_1 = cast("list[Uda]", [sino.axes_manager[i] for i in range(2)])
-        assert sino.axes_manager.shape == (600, 90)
+        assert sino.axes_manager.shape == (256, 77)
         assert sino.metadata.get_item("Signal.signal_type") == ""
         assert ax_0.name == "y"
         assert ax_1.name == "Projections"
@@ -1115,22 +1115,21 @@ class TestTestAlign:
 class TestAlignOther:
     """Test alignment of another TomoStack from an existing one."""
 
-    def test_align_other_no_shifts(self):
-        stack = ds.get_needle_data(aligned=False)
-        stack2 = stack.deepcopy()
+    def test_align_other_no_shifts(self, short_stack):
+        stack2 = short_stack.deepcopy()
         with pytest.raises(
             ValueError,
             match="No transformations have been applied to this stack",
         ):
-            stack.align_other(stack2)
+            short_stack.align_other(stack2)
 
-    def test_align_other_with_shifts(self):
-        stack = ds.get_needle_data(aligned=True)
-        stack2 = stack.deepcopy()
-        stack3 = stack.align_other(stack2)
+    def test_align_other_with_shifts(self, aligned_short_stack):
+        stack2 = aligned_short_stack.deepcopy()
+        stack3 = aligned_short_stack.align_other(stack2)
         assert isinstance(stack3, TomoStack)
         assert (
-            stack.metadata.Tomography.xshift == stack2.metadata.Tomography.xshift  # type: ignore
+            aligned_short_stack.metadata.Tomography.xshift
+            == stack2.metadata.Tomography.xshift  # type: ignore
         )
         assert (
             stack3.metadata.Tomography.xshift == 2 * stack2.metadata.Tomography.xshift  # type: ignore

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -714,38 +714,33 @@ class TestProperties:
 class TestSlicers:
     """Test inav/isig slicers."""
 
-    def test_tilt_nav_slicer(self):
-        stack = ds.get_needle_data()
-        t = stack.tilts.inav[:5]
+    def test_tilt_nav_slicer(self, full_stack):
+        t = full_stack.inav[:5].tilts
         assert isinstance(t, TomoTilts)
         assert t.data.shape == (5, 1)
 
-    def test_tilt_sig_slicer(self, caplog):
-        stack = ds.get_needle_data()
+    def test_tilt_sig_slicer(self, caplog, full_stack):
         with caplog.at_level(logging.WARNING):
-            t = stack.tilts.isig[:5]
+            t = full_stack.tilts.isig[:5]
             assert "TomoTilts does not support 'isig' slicing" in caplog.text
         assert isinstance(t, TomoTilts)
         assert t.data.shape == (77, 1)
 
-    def test_shift_nav_slicer(self):
-        stack = ds.get_needle_data()
-        t = stack.shifts.inav[:5]
+    def test_shift_nav_slicer(self, full_stack):
+        t = full_stack.shifts.inav[:5]
         assert isinstance(t, TomoShifts)
         assert t.data.shape == (5, 2)
 
-    def test_shift_sig_slicer(self, caplog):
-        stack = ds.get_needle_data()
+    def test_shift_sig_slicer(self, caplog, full_stack):
         with caplog.at_level(logging.WARNING):
-            t = stack.shifts.isig[:5]
+            t = full_stack.shifts.isig[:5]
             # warning should be triggered when slicing the TomoTilts directly
             assert "TomoShifts does not support 'isig' slicing" in caplog.text
         assert isinstance(t, TomoShifts)
         assert t.data.shape == (77, 2)
 
-    def test_tomostack_nav_slicer(self):
-        stack = ds.get_needle_data()
-        t = stack.inav[:5]
+    def test_tomostack_nav_slicer(self, full_stack):
+        t = full_stack.inav[:5]
         assert t.data.shape == (5, 256, 256)
         assert t.tilts.data.shape == (5, 1)
         assert t.shifts.data.shape == (5, 2)
@@ -753,10 +748,9 @@ class TestSlicers:
         assert isinstance(t.tilts, TomoTilts)
         assert isinstance(t.shifts, TomoShifts)
 
-    def test_tomostack_sig_slicer(self, caplog):
-        stack = ds.get_needle_data()
+    def test_tomostack_sig_slicer(self, caplog, full_stack):
         with caplog.at_level(logging.WARNING):
-            t = stack.isig[:5, :10]
+            t = full_stack.isig[:5, :10]
             # warning should not be triggered when slicing the TomoStack
             assert "TomoShifts does not support 'isig' slicing" not in caplog.text
         assert t.data.shape == (77, 10, 5)
@@ -766,14 +760,13 @@ class TestSlicers:
         assert isinstance(t.tilts, TomoTilts)
         assert isinstance(t.shifts, TomoShifts)
 
-    def test_two_d_tomo_stack_slicing(self):
+    def test_two_d_tomo_stack_slicing(self, multiframe_stack):
         """Test handling of multi-frame TomoStack with 2 navigation dimensions."""
-        s = load_serialem_multiframe_data()
-        assert s.axes_manager.shape == (2, 3, 1024, 1024)
-        assert s.data.shape == (3, 2, 1024, 1024)
+        assert multiframe_stack.axes_manager.shape == (2, 3, 1024, 1024)
+        assert multiframe_stack.data.shape == (3, 2, 1024, 1024)
         ax_0, ax_1, ax_2, ax_3 = cast(
             "list[Uda]",
-            [s.axes_manager[i] for i in range(4)],
+            [multiframe_stack.axes_manager[i] for i in range(4)],
         )
         assert ax_0.name == "Frames"
         assert ax_0.units == "images"
@@ -785,14 +778,14 @@ class TestSlicers:
         assert ax_3.units == "nm"
 
         # test inav and isig together with ranges
-        t = s.inav[:1, :2].isig[:20, :120]
+        t = multiframe_stack.inav[:1, :2].isig[:20, :120]
         assert t.axes_manager.shape == (1, 2, 20, 120)
         assert t.data.shape == (2, 1, 120, 20)
         assert t.tilts.axes_manager.shape == (1, 2, 1)
         assert t.shifts.axes_manager.shape == (1, 2, 2)
 
         # test extracting single projection
-        t2 = s.isig[:20, :120].inav[:, 2]
+        t2 = multiframe_stack.isig[:20, :120].inav[:, 2]
         assert t2.axes_manager.shape == (2, 20, 120)
         assert t2.data.shape == (2, 120, 20)
         assert t2.axes_manager[0].name == "Frames"  # type: ignore
@@ -800,7 +793,7 @@ class TestSlicers:
         assert t2.shifts.axes_manager.navigation_shape == (2,)
 
         # test extracting single frame
-        t3 = s.isig[:20, :120].inav[1, :]
+        t3 = multiframe_stack.isig[:20, :120].inav[1, :]
         assert t3.axes_manager.shape == (3, 20, 120)
         assert t3.data.shape == (3, 120, 20)
         assert t3.axes_manager[0].name == "Projections"  # type: ignore
@@ -808,7 +801,7 @@ class TestSlicers:
         assert t3.shifts.axes_manager.navigation_shape == (3,)
 
         # test extracting single frame and projection
-        t4 = s.isig[:20, :120].inav[1, 1]
+        t4 = multiframe_stack.isig[:20, :120].inav[1, 1]
         assert t4.axes_manager.shape == (20, 120)
         assert t4.data.shape == (120, 20)
         assert t4.axes_manager[0].name == "x"  # type: ignore
@@ -817,31 +810,29 @@ class TestSlicers:
         assert t4.shifts.axes_manager.navigation_shape == ()
         assert t4.tilts.data[0] == pytest.approx(-0.000488)
 
-    def test_single_pixel_nav_slicer(self):
-        stack = ds.get_needle_data()
-        t = stack.inav[30]
+    def test_single_pixel_nav_slicer(self, short_stack):
+        t = short_stack.inav[3]
         ax = t.axes_manager
         assert t.data.shape == (256, 256)
         assert ax.navigation_shape == ()
         assert ax.shape == (256, 256)
 
-    def test_single_pixel_sig_slicer_x(self, caplog):  # type: ignore
-        stack = ds.get_needle_data()
+    def test_single_pixel_sig_slicer_x(self, caplog, short_stack):  # type: ignore
         with caplog.at_level(logging.WARNING):
             # warning should be triggered and shape should be (77, 1, 256)
-            t = stack.isig[5, :]
+            t = short_stack.isig[5, :]
             assert (
                 "Slicing a TomoStack signal axis with a single pixel "
                 'is not supported. Returning a single pixel on the "x" '
                 "axis instead"
             ) in caplog.text
-        assert t.data.shape == (77, 256, 1)
-        assert t.axes_manager.shape == (77, 1, 256)
+        assert t.data.shape == (5, 256, 1)
+        assert t.axes_manager.shape == (5, 1, 256)
         ax_0, ax_1, ax_2 = cast("list[Uda]", [t.axes_manager[i] for i in range(3)])
         assert ax_0.name == "Projections"
         assert ax_1.name == "x"
         assert ax_2.name == "y"
-        assert ax_0.size == 77
+        assert ax_0.size == 5
         assert ax_1.size == 1
         assert ax_2.size == 256
         assert ax_0.units == "degrees"
@@ -850,23 +841,22 @@ class TestSlicers:
         assert ax_1.offset == pytest.approx(ax_1.scale * 5)
         assert ax_2.offset == 0
 
-    def test_single_pixel_sig_slicer_y(self, caplog):
-        stack = ds.get_needle_data()
+    def test_single_pixel_sig_slicer_y(self, caplog, short_stack):
         with caplog.at_level(logging.WARNING):
             # warning should be triggered and shape should be (77, 256, 1)
-            t = stack.isig[:, 128]
+            t = short_stack.isig[:, 128]
             assert (
                 "Slicing a TomoStack signal axis with a single pixel "
                 'is not supported. Returning a single pixel on the "y" '
                 "axis instead"
             ) in caplog.text
-        assert t.data.shape == (77, 1, 256)
-        assert t.axes_manager.shape == (77, 256, 1)
+        assert t.data.shape == (5, 1, 256)
+        assert t.axes_manager.shape == (5, 256, 1)
         ax_0, ax_1, ax_2 = cast("list[Uda]", [t.axes_manager[i] for i in range(3)])
         assert ax_0.name == "Projections"
         assert ax_1.name == "x"
         assert ax_2.name == "y"
-        assert ax_0.size == 77
+        assert ax_0.size == 5
         assert ax_1.size == 256
         assert ax_2.size == 1
         assert ax_0.units == "degrees"
@@ -875,23 +865,22 @@ class TestSlicers:
         assert ax_1.offset == 0
         assert ax_2.offset == pytest.approx(ax_2.scale * 128)
 
-    def test_single_pixel_sig_slicer_float(self, caplog):
-        stack = ds.get_needle_data()
+    def test_single_pixel_sig_slicer_float(self, caplog, short_stack):
         with caplog.at_level(logging.WARNING):
             # warning should be triggered and shape should be (77, 256, 1)
-            t = stack.isig[:, 30.4]
+            t = short_stack.isig[:, 30.4]
             assert (
                 "Slicing a TomoStack signal axis with a single pixel "
                 'is not supported. Returning a single pixel on the "y" '
                 "axis instead"
             ) in caplog.text
-        assert t.data.shape == (77, 1, 256)
-        assert t.axes_manager.shape == (77, 256, 1)
+        assert t.data.shape == (5, 1, 256)
+        assert t.axes_manager.shape == (5, 256, 1)
         ax_0, ax_1, ax_2 = cast("list[Uda]", [t.axes_manager[i] for i in range(3)])
         assert ax_0.name == "Projections"
         assert ax_1.name == "x"
         assert ax_2.name == "y"
-        assert ax_0.size == 77
+        assert ax_0.size == 5
         assert ax_1.size == 256
         assert ax_2.size == 1
         assert ax_0.units == "degrees"
@@ -903,14 +892,14 @@ class TestSlicers:
     # def test_single_pixel_nav_slicer(self):
     #     pass
 
-    def test_recstack_nav_slicer(self):
-        stack = RecStack(ds.get_needle_data())
+    def test_recstack_nav_slicer(self, full_stack):
+        stack = RecStack(full_stack)
         t = stack.inav[:5]
         assert t.data.shape == (5, 256, 256)
         assert isinstance(t, RecStack)
 
-    def test_recstack_sig_slicer(self, caplog):
-        stack = RecStack(ds.get_needle_data())
+    def test_recstack_sig_slicer(self, caplog, full_stack):
+        stack = RecStack(full_stack)
         with caplog.at_level(logging.WARNING):
             t = stack.isig[:5, :10]
             # warning should not be triggered when slicing the TomoStack
@@ -922,9 +911,8 @@ class TestSlicers:
 class TestExtractSinogram:
     """Test extract_sinogram method."""
 
-    def test_extract_sinogram(self):
-        stack = ds.get_catalyst_data()
-        sino = stack.extract_sinogram(300)
+    def test_extract_sinogram(self, full_stack):
+        sino = full_stack.extract_sinogram(300)
         ax_0, ax_1 = cast("list[Uda]", [sino.axes_manager[i] for i in range(2)])
         assert sino.axes_manager.shape == (600, 90)
         assert sino.metadata.get_item("Signal.signal_type") == ""
@@ -932,9 +920,8 @@ class TestExtractSinogram:
         assert ax_1.name == "Projections"
         assert sino.metadata.get_item("General.title") == "Sinogram at column 300"
 
-    def test_extract_sinogram_float(self):
-        stack = ds.get_catalyst_data()
-        sino = stack.extract_sinogram(106.32)
+    def test_extract_sinogram_float(self, full_stack):
+        sino = full_stack.extract_sinogram(106.32)
         ax_0, ax_1 = cast("list[Uda]", [sino.axes_manager[i] for i in range(2)])
         assert sino.axes_manager.shape == (600, 90)
         assert sino.metadata.get_item("Signal.signal_type") == ""
@@ -942,8 +929,7 @@ class TestExtractSinogram:
         assert ax_1.name == "Projections"
         assert sino.metadata.get_item("General.title") == "Sinogram at x = 106.32 nm"
 
-    def test_extract_sinogram_bad_argument_type(self):
-        stack = ds.get_catalyst_data()
+    def test_extract_sinogram_bad_argument_type(self, full_stack):
         with pytest.raises(
             TypeError,
             match=re.escape(
@@ -951,15 +937,14 @@ class TestExtractSinogram:
                 "(was <class 'str'>)",
             ),
         ):
-            stack.extract_sinogram("bad_val")  # type: ignore
+            full_stack.extract_sinogram("bad_val")  # type: ignore
 
-    def test_extract_sinogram_exception_handling(self):
+    def test_extract_sinogram_exception_handling(self, full_stack):
         # test that on exception, logger is still enabled
-        stack = ds.get_catalyst_data()
         assert logging.getLogger("etspy.base").disabled is False
         with pytest.raises(IndexError):
             # using too large of a value should trigger an error
-            stack.extract_sinogram(column=10000)
+            full_stack.extract_sinogram(column=10000)
         assert logging.getLogger("etspy.base").disabled is False
 
 

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -555,6 +555,7 @@ class TestProperties:
         )  # type: ignore
 
     def test_shift_setter_bad_dims(self, full_stack):
+        full_stack_shift_set = full_stack.deepcopy()
         with pytest.raises(
             ValueError,
             match=re.escape(
@@ -562,7 +563,7 @@ class TestProperties:
                 "size of the stack (was (77,))",
             ),
         ):
-            full_stack.shifts = np.random.rand(77)
+            full_stack_shift_set.shifts = np.random.rand(77)
         with pytest.raises(
             ValueError,
             match=re.escape(
@@ -570,15 +571,17 @@ class TestProperties:
                 "size of the stack (was (20, 1, 5))",
             ),
         ):
-            full_stack.shifts = np.random.rand(20, 1, 5)
+            full_stack_shift_set.shifts = np.random.rand(20, 1, 5)
 
     def test_shift_setter_tomoshift(self, full_stack):
+        full_stack_shift_set = full_stack.deepcopy()
         n = np.random.rand(77, 2)
         shifts = TomoShifts(n)
         assert shifts.metadata.get_item("General.title") == ""
-        full_stack.shifts = shifts  # title should be set since it was empty
+        full_stack_shift_set.shifts = shifts  # title should be set since it was empty
         assert (
-            full_stack.shifts.metadata.get_item("General.title") == "Image shift values"
+            full_stack_shift_set.shifts.metadata.get_item("General.title")
+            == "Image shift values"
         )
 
     def test_shift_setter_tomoshift_bad_dims(self, full_stack):
@@ -600,12 +603,13 @@ class TestProperties:
         assert multiframe_stack.tilts.axes_manager.shape == (2, 3, 1)
         assert multiframe_stack.tilts.data.shape == (3, 2, 1)
 
+        multiframe_stack_set_tilts = multiframe_stack.deepcopy()
         n = np.random.rand(3, 2, 1)
-        multiframe_stack.tilts = n
-        assert multiframe_stack.tilts.axes_manager.shape == (2, 3, 1)
-        assert multiframe_stack.tilts.data.shape == (3, 2, 1)
+        multiframe_stack_set_tilts.tilts = n
+        assert multiframe_stack_set_tilts.tilts.axes_manager.shape == (2, 3, 1)
+        assert multiframe_stack_set_tilts.tilts.data.shape == (3, 2, 1)
         assert (
-            multiframe_stack.tilts.metadata.get_item("General.title")
+            multiframe_stack_set_tilts.tilts.metadata.get_item("General.title")
             == "Image tilt values"
         )
 
@@ -615,12 +619,13 @@ class TestProperties:
         assert multiframe_stack.tilts.axes_manager.shape == (2, 3, 1)
         assert multiframe_stack.tilts.data.shape == (3, 2, 1)
 
+        multiframe_stack_set_tilts = multiframe_stack.deepcopy()
         n = np.random.rand(3, 2)
-        multiframe_stack.tilts = n
-        assert multiframe_stack.tilts.axes_manager.shape == (2, 3, 1)
-        assert multiframe_stack.tilts.data.shape == (3, 2, 1)
+        multiframe_stack_set_tilts.tilts = n
+        assert multiframe_stack_set_tilts.tilts.axes_manager.shape == (2, 3, 1)
+        assert multiframe_stack_set_tilts.tilts.data.shape == (3, 2, 1)
         assert (
-            multiframe_stack.tilts.metadata.get_item("General.title")
+            multiframe_stack_set_tilts.tilts.metadata.get_item("General.title")
             == "Image tilt values"
         )
 
@@ -630,6 +635,7 @@ class TestProperties:
         assert multiframe_stack.tilts.axes_manager.shape == (2, 3, 1)
         assert multiframe_stack.tilts.data.shape == (3, 2, 1)
 
+        multiframe_stack_bad_tilt_shape = multiframe_stack.deepcopy()
         n = np.random.rand(2, 3, 1)
         with pytest.raises(
             ValueError,
@@ -638,7 +644,7 @@ class TestProperties:
                 "of the stack (was (2, 3, 1))",
             ),
         ):
-            multiframe_stack.tilts = n
+            multiframe_stack_bad_tilt_shape.tilts = n
 
         n = np.random.rand(3, 2, 10)
         with pytest.raises(
@@ -648,7 +654,7 @@ class TestProperties:
                 "of the stack (was (3, 2, 10))",
             ),
         ):
-            multiframe_stack.tilts = n
+            multiframe_stack_bad_tilt_shape.tilts = n
 
     def test_multiframe_shift__setter(self, multiframe_stack):
         assert multiframe_stack.axes_manager.shape == (2, 3, 1024, 1024)
@@ -1220,7 +1226,7 @@ class TestErrorPlots:
     def test_recon_error_astra_detect_use_cuda_false(self, aligned_full_stack):
         rec_stack, error = aligned_full_stack.recon_error(
             128,
-            iterations=50,
+            iterations=2,
             constrain=True,
             cuda=None,
         )
@@ -1262,7 +1268,7 @@ class TestErrorPlots:
         rec_stack, error = aligned_full_stack.recon_error(
             128,
             algorithm="SART",
-            iterations=50,
+            iterations=2,
             constrain=True,
             cuda=None,
         )
@@ -1359,12 +1365,13 @@ class TestReconstruct:
             aligned_short_stack.reconstruct("DART", gray_levels="bad_type")  # type: ignore
 
     def test_reconstruct_dart_dart_iterations_none(self, caplog, aligned_short_stack):
+        sino = aligned_short_stack.inav[0:1].deepcopy()
         gray_levels = [
             0.0,
-            aligned_short_stack.data.max() / 2,
-            aligned_short_stack.data.max(),
+            sino.data.max() / 2,
+            sino.data.max(),
         ]
-        aligned_short_stack.reconstruct(
+        sino.reconstruct(
             "DART",
             dart_iterations=None,
             gray_levels=gray_levels,

--- a/etspy/tests/test_base.py
+++ b/etspy/tests/test_base.py
@@ -1068,55 +1068,46 @@ class TestOperations:
 class TestTestAlign:
     """Test test alignment of a TomoStack."""
 
-    def test_test_align_no_slices(self):
-        stack = ds.get_needle_data(aligned=True)
-        fig = stack.test_align()
+    def test_test_align_no_slices(self, aligned_short_stack):
+        fig = aligned_short_stack.test_align()
         assert len(fig.axes) == NUM_AXES_THREE
 
-    def test_test_align_with_angle(self):
-        stack = ds.get_needle_data(aligned=True)
-        fig = stack.test_align(tilt_rotation=3.0)
+    def test_test_align_with_angle(self, aligned_short_stack):
+        fig = aligned_short_stack.test_align(tilt_rotation=3.0)
         assert len(fig.axes) == NUM_AXES_THREE
 
-    def test_test_align_with_xshift(self):
-        stack = ds.get_needle_data(aligned=True)
-        fig = stack.test_align(tilt_shift=3.0)
+    def test_test_align_with_xshift(self, aligned_short_stack):
+        fig = aligned_short_stack.test_align(tilt_shift=3.0)
         assert len(fig.axes) == NUM_AXES_THREE
 
-    def test_test_align_with_thickness(self):
-        stack = ds.get_needle_data(aligned=True)
-        fig = stack.test_align(thickness=200)
+    def test_test_align_with_thickness(self, aligned_short_stack):
+        fig = aligned_short_stack.test_align(thickness=200)
         assert len(fig.axes) == NUM_AXES_THREE
 
-    def test_test_align_no_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        fig = stack.test_align(thickness=200, cuda=False)
+    def test_test_align_no_cuda(self, aligned_short_stack):
+        fig = aligned_short_stack.test_align(thickness=200, cuda=False)
         assert len(fig.axes) == NUM_AXES_THREE
 
     @patch("astra.use_cuda", new=lambda: False)
-    def test_test_align_cuda_none_mock_false(self):
-        stack = ds.get_needle_data(aligned=True)
-        fig = stack.test_align(thickness=200, cuda=None)
+    def test_test_align_cuda_none_mock_false(self, aligned_short_stack):
+        fig = aligned_short_stack.test_align(thickness=200, cuda=None)
         assert len(fig.axes) == NUM_AXES_THREE
 
     @patch("matplotlib.get_backend", new=lambda: "widget")
-    def test_test_align_mock_mpl_backend_none(self):
-        stack = ds.get_needle_data(aligned=True)
-        fig = stack.test_align(thickness=200)
+    def test_test_align_mock_mpl_backend_none(self, aligned_short_stack):
+        fig = aligned_short_stack.test_align(thickness=200)
         assert len(fig.axes) == NUM_AXES_THREE
         assert np.all(fig.get_size_inches() == np.array([12, 4]))
 
     @patch("matplotlib.get_backend", new=lambda: "ipympl")
-    def test_test_align_mock_mpl_backend_ipympl(self):
-        stack = ds.get_needle_data(aligned=True)
-        fig = stack.test_align(thickness=200)
+    def test_test_align_mock_mpl_backend_ipympl(self, aligned_short_stack):
+        fig = aligned_short_stack.test_align(thickness=200)
         assert len(fig.axes) == NUM_AXES_THREE
         assert np.all(fig.get_size_inches() == np.array([7, 3]))
 
     @patch("matplotlib.get_backend", new=lambda: "nbagg")
-    def test_test_align_mock_mpl_backend_nbagg(self):
-        stack = ds.get_needle_data(aligned=True)
-        fig = stack.test_align(thickness=200)
+    def test_test_align_mock_mpl_backend_nbagg(self, aligned_short_stack):
+        fig = aligned_short_stack.test_align(thickness=200)
         assert len(fig.axes) == NUM_AXES_THREE
         assert np.all(fig.get_size_inches() == np.array([8, 4]))
 

--- a/etspy/tests/test_cuda.py
+++ b/etspy/tests/test_cuda.py
@@ -25,8 +25,6 @@ except Exception:
 
 NUM_FIG_AXES = 3
 
-pytest.fixture(scope="module")
-
 
 @pytest.fixture(scope="module")
 def short_stack():
@@ -37,8 +35,7 @@ def short_stack():
 @pytest.fixture(scope="module")
 def aligned_full_stack():
     """Create full spatially registered stack from test data."""
-    s = ds.get_needle_data()
-    s = s.stack_register("PC")
+    s = ds.get_needle_data(aligned=True)
     return s
 
 

--- a/etspy/tests/test_cuda.py
+++ b/etspy/tests/test_cuda.py
@@ -25,14 +25,29 @@ except Exception:
 
 NUM_FIG_AXES = 3
 
+pytest.fixture(scope="module")
+
+
+@pytest.fixture(scope="module")
+def short_stack():
+    """Load stack from test data and truncate to 5 images."""
+    return ds.get_needle_data().inav[0:5]
+
+
+@pytest.fixture(scope="module")
+def aligned_full_stack():
+    """Create full spatially registered stack from test data."""
+    s = ds.get_needle_data()
+    s = s.stack_register("PC")
+    return s
+
 
 @pytest.mark.skipif(not astra.use_cuda(), reason="CUDA not detected")
 class TestAlignCUDA:
     """Test alignment of a TomoStack using CUDA."""
 
-    def test_test_align_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        stack.test_align(thickness=200, cuda=True)
+    def test_test_align_cuda(self, aligned_full_stack):
+        aligned_full_stack.test_align(thickness=200, cuda=True)
         fig = plt.gcf()
         assert len(fig.axes) == NUM_FIG_AXES
         plt.close(fig)
@@ -42,17 +57,15 @@ class TestAlignCUDA:
 class TestReconCUDA:
     """Test reconstruction of a TomoStack using CUDA."""
 
-    def test_recon_fbp_gpu(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
+    def test_recon_fbp_gpu(self, aligned_full_stack):
+        slices = aligned_full_stack.isig[120:121, :].deepcopy()
         rec = slices.reconstruct("FBP", cuda=True)
-        assert isinstance(stack, TomoStack)
+        assert isinstance(aligned_full_stack, TomoStack)
         assert isinstance(rec, RecStack)
         assert rec.data.shape[2] == slices.data.shape[1]
 
-    def test_recon_sirt_gpu(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
+    def test_recon_sirt_gpu(self, aligned_full_stack):
+        slices = aligned_full_stack.isig[120:121, :].deepcopy()
         rec = slices.reconstruct(
             "SIRT",
             constrain=True,
@@ -60,13 +73,12 @@ class TestReconCUDA:
             thresh=0,
             cuda=True,
         )
-        assert isinstance(stack, TomoStack)
+        assert isinstance(aligned_full_stack, TomoStack)
         assert isinstance(rec, RecStack)
         assert rec.data.shape[2] == slices.data.shape[1]
 
-    def test_recon_sart_gpu(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
+    def test_recon_sart_gpu(self, aligned_full_stack):
+        slices = aligned_full_stack.isig[120:121, :].deepcopy()
         rec = slices.reconstruct(
             "SART",
             constrain=True,
@@ -74,13 +86,12 @@ class TestReconCUDA:
             thresh=0,
             cuda=True,
         )
-        assert isinstance(stack, TomoStack)
+        assert isinstance(aligned_full_stack, TomoStack)
         assert isinstance(rec, RecStack)
         assert rec.data.shape[2] == slices.data.shape[1]
 
-    def test_recon_dart_gpu(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
+    def test_recon_dart_gpu(self, aligned_full_stack):
+        slices = aligned_full_stack.isig[120:121, :].deepcopy()
         gray_levels = [0.0, slices.data.max() / 2, slices.data.max()]
         rec = slices.reconstruct(
             "DART",
@@ -91,7 +102,7 @@ class TestReconCUDA:
             gray_levels=gray_levels,
             dart_iterations=1,
         )
-        assert isinstance(stack, TomoStack)
+        assert isinstance(aligned_full_stack, TomoStack)
         assert isinstance(rec, RecStack)
         assert rec.data.shape[2] == slices.data.shape[1]
 
@@ -100,11 +111,10 @@ class TestReconCUDA:
 class TestAstraSIRTGPU:
     """Test SIRT TomoStack reconstruction using Astra toolbox."""
 
-    def test_astra_sirt_error_gpu(self):
-        stack = ds.get_needle_data(aligned=True)
-        _, ny, _ = stack.data.shape
-        angles = stack.tilts.data.squeeze()
-        stack = stack.isig[120:121, :].squeeze()
+    def test_astra_sirt_error_gpu(self, aligned_full_stack):
+        _, ny, _ = aligned_full_stack.data.shape
+        angles = aligned_full_stack.tilts.data.squeeze()
+        stack = aligned_full_stack.isig[120:121, :].deepcopy().squeeze()
         rec_stack, error = recon.astra_error(
             stack.data,
             angles,
@@ -116,11 +126,10 @@ class TestAstraSIRTGPU:
         assert isinstance(error, np.ndarray)
         assert rec_stack.shape == (2, ny, ny)
 
-    def test_astra_sirt_error_gpu_bad_dims(self):
-        stack = ds.get_needle_data(aligned=True)
-        _, _, _ = stack.data.shape
-        angles = stack.tilts.data.squeeze()
-        stack = stack.isig[120:121, :]
+    def test_astra_sirt_error_gpu_bad_dims(self, aligned_full_stack):
+        _, _, _ = aligned_full_stack.data.shape
+        angles = aligned_full_stack.tilts.data.squeeze()
+        stack = aligned_full_stack.isig[120:121, :].deepcopy()
         with pytest.raises(
             ValueError,
             match=re.escape(
@@ -142,9 +151,8 @@ class TestAstraSIRTGPU:
 class TestReconRunCUDA:
     """Test reconstruction of TomoStack using CUDA features."""
 
-    def test_run_fbp_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
+    def test_run_fbp_cuda(self, aligned_full_stack):
+        slices = aligned_full_stack.isig[120:121, :].deepcopy()
         tilts = slices.tilts.data.squeeze()
         rec = recon.run(slices.data, tilts, "FBP", cuda=True)
         data_shape = cast("tuple[int, int, int]", rec.data.shape)
@@ -152,9 +160,8 @@ class TestReconRunCUDA:
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)
 
-    def test_run_sirt_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
+    def test_run_sirt_cuda(self, aligned_full_stack):
+        slices = aligned_full_stack.isig[120:121, :].deepcopy()
         tilts = slices.tilts.data.squeeze()
         rec = recon.run(slices.data, tilts, "SIRT", niterations=2, cuda=True)
         data_shape = cast("tuple[int, int, int]", rec.data.shape)
@@ -162,9 +169,8 @@ class TestReconRunCUDA:
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)
 
-    def test_run_sart_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
+    def test_run_sart_cuda(self, aligned_full_stack):
+        slices = aligned_full_stack.isig[120:121, :].deepcopy()
         tilts = slices.tilts.data.squeeze()
         rec = recon.run(slices.data, tilts, "SART", niterations=2, cuda=True)
         data_shape = cast("tuple[int, int, int]", rec.data.shape)
@@ -172,9 +178,8 @@ class TestReconRunCUDA:
         assert data_shape[0] == slices.data.shape[2]
         assert isinstance(rec, np.ndarray)
 
-    def test_run_dart_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
+    def test_run_dart_cuda(self, aligned_full_stack):
+        slices = aligned_full_stack.isig[120:121, :].deepcopy()
         gray_levels = [0.0, slices.data.max() / 2, slices.data.max()]
         tilts = slices.tilts.data.squeeze()
         rec = recon.run(
@@ -196,16 +201,13 @@ class TestReconRunCUDA:
 class TestStackRegisterCUDA:
     """Test StackReg alignment of a TomoStack using CUDA."""
 
-    def test_register_pc_cuda(self):
-        stack = ds.get_needle_data(aligned=False)
-        reg = stack.inav[0:20].stack_register("PC", cuda=True)
+    def test_register_pc_cuda(self, short_stack):
+        reg = short_stack.stack_register("PC", cuda=True)
         assert isinstance(reg, TomoStack)
-        assert (
-            reg.axes_manager.signal_shape == stack.inav[0:20].axes_manager.signal_shape
-        )
+        assert reg.axes_manager.signal_shape == short_stack.axes_manager.signal_shape
         assert (
             reg.axes_manager.navigation_shape
-            == stack.inav[0:20].axes_manager.navigation_shape
+            == short_stack.axes_manager.navigation_shape
         )
 
 
@@ -213,30 +215,26 @@ class TestStackRegisterCUDA:
 class TestApplyShiftsCUDA:
     """Test StackReg alignment of a TomoStack using CUDA."""
 
-    def test_apply_shifts_fourier_cuda(self):
-        stack = ds.get_needle_data(aligned=False)
-        shifts = np.random.uniform(-2, 2, [20, 2])
-        shifted = apply_shifts(stack.inav[0:20], shifts, "fourier", cuda=True)  # type: ignore
+    def test_apply_shifts_fourier_cuda(self, short_stack):
+        shifts = np.random.uniform(-2, 2, [5, 2])
+        shifted = apply_shifts(short_stack, shifts, "fourier", cuda=True)  # type: ignore
         assert isinstance(shifted, TomoStack)
         assert (
-            shifted.axes_manager.signal_shape
-            == stack.inav[0:20].axes_manager.signal_shape
+            shifted.axes_manager.signal_shape == short_stack.axes_manager.signal_shape
         )
         assert (
             shifted.axes_manager.navigation_shape
-            == stack.inav[0:20].axes_manager.navigation_shape
+            == short_stack.axes_manager.navigation_shape
         )
 
-    def test_apply_shifts_interp_cuda(self):
-        stack = ds.get_needle_data(aligned=False)
-        shifts = np.random.uniform(-2, 2, [20, 2])
-        shifted = apply_shifts(stack.inav[0:20], shifts, "interp", cuda=True)  # type: ignore
+    def test_apply_shifts_interp_cuda(self, short_stack):
+        shifts = np.random.uniform(-2, 2, [5, 2])
+        shifted = apply_shifts(short_stack, shifts, "interp", cuda=True)  # type: ignore
         assert isinstance(shifted, TomoStack)
         assert (
-            shifted.axes_manager.signal_shape
-            == stack.inav[0:20].axes_manager.signal_shape
+            shifted.axes_manager.signal_shape == short_stack.axes_manager.signal_shape
         )
         assert (
             shifted.axes_manager.navigation_shape
-            == stack.inav[0:20].axes_manager.navigation_shape
+            == short_stack.axes_manager.navigation_shape
         )

--- a/etspy/tests/test_recon.py
+++ b/etspy/tests/test_recon.py
@@ -12,34 +12,43 @@ from etspy import recon
 from etspy.base import RecStack, TomoStack
 
 
+@pytest.fixture(scope="module")
+def aligned_full_stack():
+    """Create full spatially registered stack from test data."""
+    s = ds.get_needle_data(aligned=True)
+    return s
+
+
+@pytest.fixture(scope="module")
+def aligned_sinogram(aligned_full_stack):
+    """Extract single sinogram from aligned full stack."""
+    s = aligned_full_stack.isig[120:121, :].deepcopy()
+    return s
+
+
 class TestReconstruction:
     """Test TomoStack reconstruction methods."""
 
-    def test_recon_no_tilts(self):
-        stack = ds.get_needle_data(aligned=True)
-        del stack.tilts
-        slices = stack.isig[120:121, :].deepcopy()
+    def test_recon_no_tilts(self, aligned_sinogram):
+        aligned_sinogram_no_tilts = aligned_sinogram.deepcopy()
+        del aligned_sinogram_no_tilts.tilts
         with pytest.raises(
             ValueError,
             match=r"Tilts are not defined in stack.tilts \(values were all zeros\). "
             r"Please set tilt values before alignment.",
         ):
-            slices.reconstruct("FBP")
+            aligned_sinogram_no_tilts.reconstruct("FBP")
 
-    def test_recon_single_slice(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :]
-        tilts = stack.tilts.data.squeeze()
-        rec = recon.run(slices.data, tilts, "FBP", cuda=False)
-        assert isinstance(stack, TomoStack)
+    def test_recon_single_slice(self, aligned_full_stack, aligned_sinogram):
+        tilts = aligned_full_stack.tilts.data.squeeze()
+        rec = recon.run(aligned_sinogram.data, tilts, "FBP", cuda=False)
+        assert isinstance(aligned_full_stack, TomoStack)
         assert isinstance(rec, np.ndarray)
         data_shape = rec.data.shape
         data_shape = cast("tuple[int, int, int]", data_shape)  # cast for type checking
-        assert data_shape[2] == slices.data.shape[1]
+        assert data_shape[2] == aligned_sinogram.data.shape[1]
 
-    def test_recon_unknown_algorithm(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
+    def test_recon_unknown_algorithm(self, aligned_sinogram):
         bad_method = "UNKNOWN"
         with pytest.raises(
             ValueError,
@@ -48,57 +57,47 @@ class TestReconstruction:
                 '["FBP", "SIRT", "SART", or "DART"]',
             ),
         ):
-            slices.reconstruct(bad_method)  # type: ignore
+            aligned_sinogram.reconstruct(bad_method)  # type: ignore
 
-    def test_recon_fbp_cpu(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
-        rec = slices.reconstruct("FBP", cuda=False)
-        assert isinstance(stack, TomoStack)
+    def test_recon_fbp_cpu(self, aligned_sinogram):
+        rec = aligned_sinogram.reconstruct("FBP", cuda=False)
         assert isinstance(rec, RecStack)
-        assert rec.data.shape[2] == slices.data.shape[1]
+        assert rec.data.shape[2] == aligned_sinogram.data.shape[1]
 
-    def test_recon_fbp_cpu_multicore(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:122, :].deepcopy()
-        rec = slices.reconstruct("FBP", cuda=False)
-        assert isinstance(stack, TomoStack)
+    def test_recon_fbp_cpu_multicore(self, aligned_sinogram):
+        rec = aligned_sinogram.reconstruct("FBP", cuda=False)
         assert isinstance(rec, RecStack)
-        assert rec.data.shape[2] == slices.data.shape[1]
+        assert rec.data.shape[2] == aligned_sinogram.data.shape[1]
 
-    def test_recon_sirt_cpu(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
-        rec = slices.reconstruct(
+    def test_recon_sirt_cpu(self, aligned_sinogram):
+        rec = aligned_sinogram.reconstruct(
             "SIRT",
             constrain=True,
             iterations=2,
             thresh=0,
             cuda=False,
         )
-        assert isinstance(stack, TomoStack)
         assert isinstance(rec, RecStack)
-        assert rec.data.shape[2] == slices.data.shape[1]
+        assert rec.data.shape[2] == aligned_sinogram.data.shape[1]
 
-    def test_recon_sart_cpu(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
-        rec = slices.reconstruct(
+    def test_recon_sart_cpu(self, aligned_sinogram):
+        rec = aligned_sinogram.reconstruct(
             "SART",
             constrain=True,
             iterations=2,
             thresh=0,
             cuda=False,
         )
-        assert isinstance(stack, TomoStack)
         assert isinstance(rec, RecStack)
-        assert rec.data.shape[2] == slices.data.shape[1]
+        assert rec.data.shape[2] == aligned_sinogram.data.shape[1]
 
-    def test_recon_dart_cpu(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
-        gray_levels = [0.0, slices.data.max() / 2, slices.data.max()]
-        rec = slices.reconstruct(
+    def test_recon_dart_cpu(self, aligned_sinogram):
+        gray_levels = [
+            0.0,
+            aligned_sinogram.data.max() / 2,
+            aligned_sinogram.data.max(),
+        ]
+        rec = aligned_sinogram.reconstruct(
             "DART",
             iterations=2,
             cuda=False,
@@ -106,15 +105,16 @@ class TestReconstruction:
             dart_iterations=1,
             ncores=1,
         )
-        assert isinstance(stack, TomoStack)
         assert isinstance(rec, RecStack)
-        assert rec.data.shape[2] == slices.data.shape[1]
+        assert rec.data.shape[2] == aligned_sinogram.data.shape[1]
 
-    def test_recon_dart_cpu_multicore(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:122, :].deepcopy()
-        gray_levels = [0.0, slices.data.max() / 2, slices.data.max()]
-        rec = slices.reconstruct(
+    def test_recon_dart_cpu_multicore(self, aligned_sinogram):
+        gray_levels = [
+            0.0,
+            aligned_sinogram.data.max() / 2,
+            aligned_sinogram.data.max(),
+        ]
+        rec = aligned_sinogram.reconstruct(
             "DART",
             iterations=2,
             cuda=False,
@@ -122,61 +122,70 @@ class TestReconstruction:
             dart_iterations=1,
             ncores=1,
         )
-        assert isinstance(stack, TomoStack)
         assert isinstance(rec, RecStack)
-        assert rec.data.shape[2] == slices.data.shape[1]
+        assert rec.data.shape[2] == aligned_sinogram.data.shape[1]
 
 
 class TestReconRun:
     """Test the reconstruction "run" method."""
 
-    def test_run_fbp_no_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
-        tilts = slices.tilts.data.squeeze()
-        rec = recon.run(slices.data, tilts, "FBP", cuda=False)
+    def test_run_fbp_no_cuda(self, aligned_sinogram):
+        tilts = aligned_sinogram.tilts.data.squeeze()
+        rec = recon.run(aligned_sinogram.data, tilts, "FBP", cuda=False)
         data_shape = cast("tuple[int, int, int]", rec.data.shape)
-        assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
-        assert data_shape[0] == slices.data.shape[2]
+        assert data_shape == (
+            1,
+            aligned_sinogram.data.shape[1],
+            aligned_sinogram.data.shape[1],
+        )
+        assert data_shape[0] == aligned_sinogram.data.shape[2]
         assert isinstance(rec, np.ndarray)
 
-    def test_run_fbp_no_cuda_2d_array(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
-        tilts = slices.tilts.data.squeeze()
-        rec = recon.run(slices.data.squeeze(), tilts, "FBP", cuda=False)
+    def test_run_fbp_no_cuda_2d_array(self, aligned_sinogram):
+        tilts = aligned_sinogram.tilts.data.squeeze()
+        rec = recon.run(aligned_sinogram.data.squeeze(), tilts, "FBP", cuda=False)
         data_shape = cast("tuple[int, int, int]", rec.data.shape)
-        assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
-        assert data_shape[0] == slices.data.shape[2]
+        assert data_shape == (
+            1,
+            aligned_sinogram.data.shape[1],
+            aligned_sinogram.data.shape[1],
+        )
+        assert data_shape[0] == aligned_sinogram.data.shape[2]
         assert isinstance(rec, np.ndarray)
 
-    def test_run_sirt_no_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
-        tilts = slices.tilts.data.squeeze()
-        rec = recon.run(slices.data, tilts, "SIRT", niterations=2, cuda=False)
+    def test_run_sirt_no_cuda(self, aligned_sinogram):
+        tilts = aligned_sinogram.tilts.data.squeeze()
+        rec = recon.run(aligned_sinogram.data, tilts, "SIRT", niterations=2, cuda=False)
         data_shape = cast("tuple[int, int, int]", rec.data.shape)
-        assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
-        assert data_shape[0] == slices.data.shape[2]
+        assert data_shape == (
+            1,
+            aligned_sinogram.data.shape[1],
+            aligned_sinogram.data.shape[1],
+        )
+        assert data_shape[0] == aligned_sinogram.data.shape[2]
         assert isinstance(rec, np.ndarray)
 
-    def test_run_sart_no_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
-        tilts = slices.tilts.data.squeeze()
-        rec = recon.run(slices.data, tilts, "SART", niterations=2, cuda=False)
+    def test_run_sart_no_cuda(self, aligned_sinogram):
+        tilts = aligned_sinogram.tilts.data.squeeze()
+        rec = recon.run(aligned_sinogram.data, tilts, "SART", niterations=2, cuda=False)
         data_shape = cast("tuple[int, int, int]", rec.data.shape)
-        assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
-        assert data_shape[0] == slices.data.shape[2]
+        assert data_shape == (
+            1,
+            aligned_sinogram.data.shape[1],
+            aligned_sinogram.data.shape[1],
+        )
+        assert data_shape[0] == aligned_sinogram.data.shape[2]
         assert isinstance(rec, np.ndarray)
 
-    def test_run_dart_no_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
-        gray_levels = [0.0, slices.data.max() / 2, slices.data.max()]
-        tilts = slices.tilts.data.squeeze()
+    def test_run_dart_no_cuda(self, aligned_sinogram):
+        gray_levels = [
+            0.0,
+            aligned_sinogram.data.max() / 2,
+            aligned_sinogram.data.max(),
+        ]
+        tilts = aligned_sinogram.tilts.data.squeeze()
         rec = recon.run(
-            slices.data,
+            aligned_sinogram.data,
             tilts,
             "DART",
             niterations=2,
@@ -185,18 +194,20 @@ class TestReconRun:
             dart_iterations=1,
         )
         data_shape = cast("tuple[int, int, int]", rec.data.shape)
-        assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
-        assert data_shape[0] == slices.data.shape[2]
+        assert data_shape == (
+            1,
+            aligned_sinogram.data.shape[1],
+            aligned_sinogram.data.shape[1],
+        )
+        assert data_shape[0] == aligned_sinogram.data.shape[2]
         assert isinstance(rec, np.ndarray)
 
     @pytest.mark.skipif(not astra.use_cuda(), reason="CUDA not detected")
-    def test_run_dart_no_gray_levels_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
-        tilts = slices.tilts.data.squeeze()
+    def test_run_dart_no_gray_levels_cuda(self, aligned_sinogram):
+        tilts = aligned_sinogram.tilts.data.squeeze()
         with pytest.raises(ValueError, match="gray_levels must be provided for DART"):
             recon.run(
-                slices.data,
+                aligned_sinogram.data,
                 tilts,
                 "DART",
                 niterations=2,
@@ -205,13 +216,11 @@ class TestReconRun:
                 dart_iterations=1,
             )
 
-    def test_run_dart_no_gray_levels_no_cuda(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
-        tilts = slices.tilts.data.squeeze()
+    def test_run_dart_no_gray_levels_no_cuda(self, aligned_sinogram):
+        tilts = aligned_sinogram.tilts.data.squeeze()
         with pytest.raises(ValueError, match="gray_levels must be provided for DART"):
             recon.run(
-                slices.data,
+                aligned_sinogram.data,
                 tilts,
                 "DART",
                 niterations=2,
@@ -220,36 +229,40 @@ class TestReconRun:
                 dart_iterations=1,
             )
 
-    def test_run_dart_no_cuda_no_progress(self):
-        stack = ds.get_needle_data(aligned=True)
-        slices = stack.isig[120:121, :].deepcopy()
-        tilts = slices.tilts.data.squeeze()
+    def test_run_dart_no_cuda_no_progress(self, aligned_sinogram):
+        tilts = aligned_sinogram.tilts.data.squeeze()
         rec = recon.run(
-            slices.data,
+            aligned_sinogram.data,
             tilts,
             "DART",
             niterations=2,
             cuda=False,
-            gray_levels=[0.0, slices.data.max() / 2, slices.data.max()],
+            gray_levels=[
+                0.0,
+                aligned_sinogram.data.max() / 2,
+                aligned_sinogram.data.max(),
+            ],
             dart_iterations=1,
             show_progressbar=False,
         )
         data_shape = cast("tuple[int, int, int]", rec.data.shape)
-        assert data_shape == (1, slices.data.shape[1], slices.data.shape[1])
-        assert data_shape[0] == slices.data.shape[2]
+        assert data_shape == (
+            1,
+            aligned_sinogram.data.shape[1],
+            aligned_sinogram.data.shape[1],
+        )
+        assert data_shape[0] == aligned_sinogram.data.shape[2]
         assert isinstance(rec, np.ndarray)
 
 
 class TestAstraError:
     """Test Astra toolbox errors."""
 
-    def test_astra_sirt_error_cpu(self):
-        stack = ds.get_needle_data(aligned=True)
-        _, ny, _ = stack.data.shape
-        angles = stack.tilts.data.squeeze()
-        sino = stack.isig[120:121, :].data.squeeze()
+    def test_astra_sirt_error_cpu(self, aligned_sinogram):
+        _, ny, _ = aligned_sinogram.data.shape
+        angles = aligned_sinogram.tilts.data.squeeze()
         rec_stack, error = recon.astra_error(
-            sino,
+            aligned_sinogram.data[:, :, 0],
             angles,
             iterations=2,
             constrain=True,
@@ -259,13 +272,11 @@ class TestAstraError:
         assert isinstance(error, np.ndarray)
         assert rec_stack.shape == (2, ny, ny)
 
-    def test_astra_sart_error_cpu(self):
-        stack = ds.get_needle_data(aligned=True)
-        _, ny, _ = stack.data.shape
-        angles = stack.tilts.data.squeeze()
-        sino = stack.isig[120:121, :].data.squeeze()
+    def test_astra_sart_error_cpu(self, aligned_sinogram):
+        _, ny, _ = aligned_sinogram.data.shape
+        angles = aligned_sinogram.tilts.data.squeeze()
         rec_stack, error = recon.astra_error(
-            sino,
+            aligned_sinogram.data[:, :, 0],
             angles,
             method="SART",
             iterations=2,
@@ -276,9 +287,8 @@ class TestAstraError:
         assert isinstance(error, np.ndarray)
         assert rec_stack.shape == (2, ny, ny)
 
-    def test_astra_error_cpu_bad_dims(self):
-        stack = ds.get_needle_data(aligned=True)
-        angles = stack.tilts.data.squeeze()
+    def test_astra_error_cpu_bad_dims(self, aligned_sinogram):
+        angles = aligned_sinogram.tilts.data.squeeze()
         sino = np.random.rand(3, 5, 10)
         with pytest.raises(
             ValueError,
@@ -297,9 +307,8 @@ class TestAstraError:
                 cuda=False,
             )
 
-    def test_astra_error_cpu_nangles_mismatch(self):
-        stack = ds.get_needle_data(aligned=True)
-        angles = stack.tilts.data.squeeze()
+    def test_astra_error_cpu_nangles_mismatch(self, aligned_sinogram):
+        angles = aligned_sinogram.tilts.data.squeeze()
         sino = np.random.rand(3, 10)
         with pytest.raises(
             ValueError,

--- a/etspy/tests/test_simulation.py
+++ b/etspy/tests/test_simulation.py
@@ -10,13 +10,27 @@ from etspy import simulation as sim
 from etspy.base import TomoStack
 
 
+@pytest.fixture(scope="module")
+def catalyst_proj():
+    """Create full projection series of simulated catalyst model for testing."""
+    model = sim.create_catalyst_model(0, volsize=(10, 10, 10))
+    proj = sim.create_model_tilt_series(model)
+    return proj
+
+
+@pytest.fixture(scope="module")
+def catalyst_model():
+    """Create simulated catalyst model for testing."""
+    model = sim.create_catalyst_model(0, volsize=(10, 10, 10))
+    return model
+
+
 class TestModels:
     """Test model creation."""
 
-    def test_catalyst_model(self):
-        stack = sim.create_catalyst_model(0, volsize=(10, 10, 10))
-        assert stack.data.shape == (10, 10, 10)
-        assert isinstance(stack, Signal2D)
+    def test_catalyst_model(self, catalyst_model):
+        assert catalyst_model.data.shape == (10, 10, 10)
+        assert isinstance(catalyst_model, Signal2D)
 
     def test_catalyst_model_with_particle(self):
         stack = sim.create_catalyst_model(
@@ -38,27 +52,28 @@ class TestModels:
         assert model.data.shape == (400, 400, 400)
         assert isinstance(model, Signal2D)
 
-    def test_tilt_series_model(self):
-        stack = sim.create_catalyst_model(0, volsize=(10, 10, 10))
-        proj = sim.create_model_tilt_series(stack, np.arange(0, 15, 5))
+    def test_tilt_series_model(self, catalyst_model):
+        proj = sim.create_model_tilt_series(catalyst_model, np.arange(0, 15, 5))
         assert isinstance(proj, TomoStack)
         assert proj.data.shape == (3, 10, 10)
         assert proj.tilts.data.shape == (3, 1)
         assert proj.shifts.data.shape == (3, 2)
         assert np.all(proj.tilts.data == np.array([[0], [5], [10]]))
 
-    def test_tilt_series_model_no_cuda(self):
-        stack = sim.create_catalyst_model(0, volsize=(10, 10, 10))
-        proj = sim.create_model_tilt_series(stack, np.arange(0, 15, 5), cuda=False)
+    def test_tilt_series_model_no_cuda(self, catalyst_model):
+        proj = sim.create_model_tilt_series(
+            catalyst_model,
+            np.arange(0, 15, 5),
+            cuda=False,
+        )
         assert isinstance(proj, TomoStack)
         assert proj.data.shape == (3, 10, 10)
         assert proj.tilts.data.shape == (3, 1)
         assert proj.shifts.data.shape == (3, 2)
         assert np.all(proj.tilts.data == np.array([[0], [5], [10]]))
 
-    def test_tilt_series_model_no_tilts(self):
-        stack = sim.create_catalyst_model(0, volsize=(10, 10, 10))
-        proj = sim.create_model_tilt_series(stack, None)
+    def test_tilt_series_model_no_tilts(self, catalyst_model):
+        proj = sim.create_model_tilt_series(catalyst_model, None)
         assert isinstance(proj, TomoStack)
         assert proj.data.shape == (90, 10, 10)
         assert proj.tilts.data.shape == (90, 1)
@@ -69,73 +84,61 @@ class TestModels:
 class TestModifications:
     """Test modifications to model during creation."""
 
-    def test_misalign_stack(self):
-        model = sim.create_catalyst_model(0, volsize=(10, 10, 10))
-        stack = sim.create_model_tilt_series(model)
-        shifted = sim.misalign_stack(stack)
-        assert stack.shifts.data.sum() == 0
+    def test_misalign_stack(self, catalyst_proj):
+        shifted = sim.misalign_stack(catalyst_proj)
+        assert catalyst_proj.shifts.data.sum() == 0
         assert shifted.data.shape == (90, 10, 10)
         assert abs(shifted.shifts.data).sum() > 0
 
-    def test_misalign_stack_with_shift(self):
-        model = sim.create_catalyst_model(0, volsize=(10, 10, 10))
-        stack = sim.create_model_tilt_series(model)
-        shifted = sim.misalign_stack(stack, tilt_shift=2)
-        assert stack.shifts.data.sum() == 0
+    def test_misalign_stack_with_shift(self, catalyst_proj):
+        shifted = sim.misalign_stack(catalyst_proj, tilt_shift=2)
+        assert catalyst_proj.shifts.data.sum() == 0
         assert shifted.data.shape == (90, 10, 10)
         assert abs(shifted.shifts.data).sum() > 0
 
-    def test_misalign_stack_with_xonly(self):
-        model = sim.create_catalyst_model(0, volsize=(10, 10, 10))
-        stack = sim.create_model_tilt_series(model)
-        shifted = sim.misalign_stack(stack, y_only=True)
-        assert stack.shifts.data.sum() == 0
+    def test_misalign_stack_with_xonly(self, catalyst_proj):
+        shifted = sim.misalign_stack(catalyst_proj, y_only=True)
+        assert catalyst_proj.shifts.data.sum() == 0
         assert shifted.data.shape == (90, 10, 10)
         assert np.all(shifted.shifts.data[:, 1] == 0)
         assert abs(shifted.shifts.data[:, 0]).sum() > 0
 
-    def test_misalign_stack_with_rotation(self):
-        model = sim.create_catalyst_model(0, volsize=(10, 10, 10))
-        stack = sim.create_model_tilt_series(model)
-        shifted = sim.misalign_stack(stack, tilt_rotate=2)
-        assert stack.shifts.data.sum() == 0
+    def test_misalign_stack_with_rotation(self, catalyst_proj):
+        shifted = sim.misalign_stack(catalyst_proj, tilt_rotate=2)
+        assert catalyst_proj.shifts.data.sum() == 0
         assert shifted.data.shape == (90, 10, 10)
         assert abs(shifted.shifts.data).sum() > 0
 
     @pytest.mark.filterwarnings("ignore:divide by zero encountered")
-    def test_add_noise_gaussian(self):
-        model = sim.create_catalyst_model(0, volsize=(10, 10, 10))
-        stack = sim.create_model_tilt_series(model)
+    def test_add_noise_gaussian(self, catalyst_proj):
         # omit the first image because its std is 0
         stack_snr = (
-            stack.data[1:].mean(axis=(1,2)) / stack.data[1:].std(axis=(1,2))
+            catalyst_proj.data[1:].mean(axis=(1, 2))
+            / catalyst_proj.data[1:].std(axis=(1, 2))
         ).mean()
-        noisy = sim.add_noise(stack, "gaussian")
+        noisy = sim.add_noise(catalyst_proj, "gaussian")
         noisy_snr = (
-            noisy.data[1:].mean(axis=(1,2)) / noisy.data[1:].std(axis=(1,2))
+            noisy.data[1:].mean(axis=(1, 2)) / noisy.data[1:].std(axis=(1, 2))
         ).mean()
         assert noisy.data.shape == (90, 10, 10)
         # ensure signal to noise is higher for non-noisy signal
         assert stack_snr > noisy_snr
 
     @pytest.mark.filterwarnings("ignore:divide by zero encountered")
-    def test_add_noise_poissanian(self):
-        model = sim.create_catalyst_model(0, volsize=(10, 10, 10))
-        stack = sim.create_model_tilt_series(model)
+    def test_add_noise_poissanian(self, catalyst_proj):
         stack_snr = (
-            stack.data[1:].mean(axis=(1,2)) / stack.data[1:].std(axis=(1,2))
+            catalyst_proj.data[1:].mean(axis=(1, 2))
+            / catalyst_proj.data[1:].std(axis=(1, 2))
         ).mean()
-        noisy = sim.add_noise(stack, "poissonian")
+        noisy = sim.add_noise(catalyst_proj, "poissonian")
         noisy_snr = (
-            noisy.data[1:].mean(axis=(1,2)) / noisy.data[1:].std(axis=(1,2))
+            noisy.data[1:].mean(axis=(1, 2)) / noisy.data[1:].std(axis=(1, 2))
         ).mean()
         assert noisy.data.shape == (90, 10, 10)
         # ensure signal to noise is higher for non-noisy signal
         assert stack_snr > noisy_snr
 
-    def test_add_noise_invalid_type(self):
-        model = sim.create_catalyst_model(0, volsize=(10, 10, 10))
-        stack = sim.create_model_tilt_series(model)
+    def test_add_noise_invalid_type(self, catalyst_proj):
         with pytest.raises(
             ValueError,
             match=re.escape(
@@ -143,4 +146,4 @@ class TestModifications:
                 '["gaussian", "poissonian", or "shot"].',
             ),
         ):
-            sim.add_noise(stack, "bad value") # type: ignore
+            sim.add_noise(catalyst_proj, "bad value")  # type: ignore

--- a/etspy/tests/test_utils.py
+++ b/etspy/tests/test_utils.py
@@ -6,8 +6,7 @@ import numpy as np
 import pytest
 
 from etspy import datasets as ds
-from etspy import io, utils
-from etspy.api import etspy_path
+from etspy import utils
 from etspy.base import TomoStack
 
 from . import hspy_mrc_reader_check, load_serialem_multiframe_data
@@ -131,31 +130,41 @@ class TestWeightingFilter:
 
     def test_weighting_filter_shepp_logan(self, aligned_short_stack):
         filtered = utils.filter_stack(
-            aligned_short_stack, filter_name="shepp-logan", cutoff=0.5
+            aligned_short_stack,
+            filter_name="shepp-logan",
+            cutoff=0.5,
         )
         assert isinstance(filtered, TomoStack)
 
     def test_weighting_filter_ram_lak(self, aligned_short_stack):
         filtered = utils.filter_stack(
-            aligned_short_stack, filter_name="ram-lak", cutoff=0.5
+            aligned_short_stack,
+            filter_name="ram-lak",
+            cutoff=0.5,
         )
         assert isinstance(filtered, TomoStack)
 
     def test_weighting_filter_cosine(self, aligned_short_stack):
         filtered = utils.filter_stack(
-            aligned_short_stack, filter_name="cosine", cutoff=0.5
+            aligned_short_stack,
+            filter_name="cosine",
+            cutoff=0.5,
         )
         assert isinstance(filtered, TomoStack)
 
     def test_weighting_filter_shepp_hanning(self, aligned_short_stack):
         filtered = utils.filter_stack(
-            aligned_short_stack, filter_name="hanning", cutoff=0.5
+            aligned_short_stack,
+            filter_name="hanning",
+            cutoff=0.5,
         )
         assert isinstance(filtered, TomoStack)
 
     def test_weighting_filter_two_dimensional_data(self, aligned_short_stack):
         filtered = utils.filter_stack(
-            aligned_short_stack, filter_name="hanning", cutoff=0.5
+            aligned_short_stack,
+            filter_name="hanning",
+            cutoff=0.5,
         )
         assert isinstance(filtered, TomoStack)
 

--- a/etspy/tests/test_utils.py
+++ b/etspy/tests/test_utils.py
@@ -20,6 +20,14 @@ else:
     hspy_mrc_broken = False
 
 
+@pytest.fixture(scope="module")
+def aligned_short_stack():
+    """Create truncated and spatially registered stack from test data."""
+    s = ds.get_needle_data().inav[0:5]
+    s = s.stack_register("PC")
+    return s
+
+
 @pytest.mark.skipif(hspy_mrc_broken is True, reason="Hyperspy MRC reader broken")
 class TestMultiframeAverage:
     """Test taking a multiframe average of a stack."""
@@ -55,27 +63,19 @@ class TestMultiframeAverage:
 class TestWeightStack:
     """Test weighting a stack."""
 
-    def test_weight_stack_low(self):
-        stack = ds.get_needle_data(aligned=True)
-        stack = stack.inav[0:3]
-        reg = utils.weight_stack(stack, accuracy="low")
+    def test_weight_stack_low(self, aligned_short_stack):
+        reg = utils.weight_stack(aligned_short_stack, accuracy="low")
         assert isinstance(reg, TomoStack)
 
-    def test_weight_stack_medium(self):
-        stack = ds.get_needle_data(aligned=True)
-        stack = stack.inav[0:3]
-        reg = utils.weight_stack(stack, accuracy="medium")
+    def test_weight_stack_medium(self, aligned_short_stack):
+        reg = utils.weight_stack(aligned_short_stack, accuracy="medium")
         assert isinstance(reg, TomoStack)
 
-    def test_weight_stack_high(self):
-        stack = ds.get_needle_data(aligned=True)
-        stack = stack.inav[0:3]
-        reg = utils.weight_stack(stack, accuracy="high")
+    def test_weight_stack_high(self, aligned_short_stack):
+        reg = utils.weight_stack(aligned_short_stack, accuracy="high")
         assert isinstance(reg, TomoStack)
 
-    def test_weight_stack_bad_accuracy(self):
-        stack = ds.get_needle_data(aligned=True)
-        stack = stack.inav[0:3]
+    def test_weight_stack_bad_accuracy(self, aligned_short_stack):
         bad_accuracy = "wrong"
         with pytest.raises(
             ValueError,
@@ -85,7 +85,7 @@ class TestWeightStack:
             ),
         ):
             utils.weight_stack(
-                stack,
+                aligned_short_stack,
                 accuracy="wrong",  # pyright: ignore[reportArgumentType]
             )
 
@@ -123,39 +123,37 @@ class TestHelperUtils:
 class TestWeightingFilter:
     """Test weighting filter."""
 
-    def test_weighting_filter_shepp_logan(self):
-        stack = ds.get_needle_data(aligned=True)
-        stack = stack.inav[0:3]
-        filtered = utils.filter_stack(stack, filter_name="shepp-logan", cutoff=0.5)
+    def test_weighting_filter_shepp_logan(self, aligned_short_stack):
+        filtered = utils.filter_stack(
+            aligned_short_stack, filter_name="shepp-logan", cutoff=0.5
+        )
         assert isinstance(filtered, TomoStack)
 
-    def test_weighting_filter_ram_lak(self):
-        stack = ds.get_needle_data(aligned=True)
-        stack = stack.inav[0:3]
-        filtered = utils.filter_stack(stack, filter_name="ram-lak", cutoff=0.5)
+    def test_weighting_filter_ram_lak(self, aligned_short_stack):
+        filtered = utils.filter_stack(
+            aligned_short_stack, filter_name="ram-lak", cutoff=0.5
+        )
         assert isinstance(filtered, TomoStack)
 
-    def test_weighting_filter_cosine(self):
-        stack = ds.get_needle_data(aligned=True)
-        stack = stack.inav[0:3]
-        filtered = utils.filter_stack(stack, filter_name="cosine", cutoff=0.5)
+    def test_weighting_filter_cosine(self, aligned_short_stack):
+        filtered = utils.filter_stack(
+            aligned_short_stack, filter_name="cosine", cutoff=0.5
+        )
         assert isinstance(filtered, TomoStack)
 
-    def test_weighting_filter_shepp_hanning(self):
-        stack = ds.get_needle_data(aligned=True)
-        stack = stack.inav[0:3]
-        filtered = utils.filter_stack(stack, filter_name="hanning", cutoff=0.5)
+    def test_weighting_filter_shepp_hanning(self, aligned_short_stack):
+        filtered = utils.filter_stack(
+            aligned_short_stack, filter_name="hanning", cutoff=0.5
+        )
         assert isinstance(filtered, TomoStack)
 
-    def test_weighting_filter_two_dimensional_data(self):
-        stack = ds.get_needle_data(aligned=True)
-        stack = stack.inav[0]
-        filtered = utils.filter_stack(stack, filter_name="hanning", cutoff=0.5)
+    def test_weighting_filter_two_dimensional_data(self, aligned_short_stack):
+        filtered = utils.filter_stack(
+            aligned_short_stack, filter_name="hanning", cutoff=0.5
+        )
         assert isinstance(filtered, TomoStack)
 
-    def test_weighting_filter_bad_filter(self):
-        stack = ds.get_needle_data(aligned=True)
-        stack = stack.inav[0:3]
+    def test_weighting_filter_bad_filter(self, aligned_short_stack):
         bad_filter = "wrong"
         with pytest.raises(
             ValueError,
@@ -165,7 +163,7 @@ class TestWeightingFilter:
             ),
         ):
             utils.filter_stack(
-                stack,
+                aligned_short_stack,
                 filter_name="wrong",  # pyright: ignore[reportArgumentType]
                 cutoff=0.5,
             )

--- a/etspy/tests/test_utils.py
+++ b/etspy/tests/test_utils.py
@@ -28,34 +28,40 @@ def aligned_short_stack():
     return s
 
 
+@pytest.fixture(scope="module")
+def multiframe_small_stack():
+    """Load multiframe stack."""
+    s = load_serialem_multiframe_data()
+    return s.isig[500:524, 500:524]
+
+
 @pytest.mark.skipif(hspy_mrc_broken is True, reason="Hyperspy MRC reader broken")
 class TestMultiframeAverage:
     """Test taking a multiframe average of a stack."""
 
-    def test_register_serialem_stack(self):
-        dirname = etspy_path / "tests" / "test_data" / "SerialEM_Multiframe_Test"
-        files = dirname.glob("*.mrc")
-        stack = io.load(list(files))
-        stack_avg = utils.register_serialem_stack(stack, ncpus=1)
+    def test_register_serialem_stack(self, multiframe_small_stack):
+        stack_avg = utils.register_serialem_stack(
+            multiframe_small_stack,
+            ncpus=1,
+        )
         data_shape = 3
         assert isinstance(stack_avg, TomoStack)
         assert stack_avg.data.shape[0] == data_shape
 
-    def test_register_serialem_stack_multicpu(self):
-        dirname = etspy_path / "tests" / "test_data" / "SerialEM_Multiframe_Test"
-        files = dirname.glob("*.mrc")
-        stack = io.load(list(files))
-        stack_avg = utils.register_serialem_stack(stack, ncpus=2)
+    def test_register_serialem_stack_multicpu(self, multiframe_small_stack):
+        stack_avg = utils.register_serialem_stack(multiframe_small_stack, ncpus=2)
         data_shape = 3
         assert isinstance(stack_avg, TomoStack)
         assert stack_avg.data.shape[0] == data_shape
 
-    def test_multiaverage(self):
-        dirname = etspy_path / "tests" / "test_data" / "SerialEM_Multiframe_Test"
-        files = dirname.glob("*.mrc")
-        stack = io.load(list(files))
-        _, nframes, ny, nx = stack.data.shape
-        stack_avg = utils.multiaverage(stack.data[0], nframes, ny, nx)
+    def test_multiaverage(self, multiframe_small_stack):
+        _, nframes, ny, nx = multiframe_small_stack.data.shape
+        stack_avg = utils.multiaverage(
+            multiframe_small_stack.data[0],
+            nframes,
+            ny,
+            nx,
+        )
         assert isinstance(stack_avg, np.ndarray)
         assert stack_avg.shape == (ny, nx)
 
@@ -168,10 +174,9 @@ class TestWeightingFilter:
                 cutoff=0.5,
             )
 
-    def test_weighting_filter_bad_stack_shape(self):
-        stack = load_serialem_multiframe_data()
+    def test_weighting_filter_bad_stack_shape(self, multiframe_small_stack):
         with pytest.raises(
             ValueError,
             match="Method can only be applied to 2 or 3-dimensional stacks",
         ):
-            utils.filter_stack(stack)
+            utils.filter_stack(multiframe_small_stack)


### PR DESCRIPTION
### Description of the change
During the unit tests, there were many redundant `TomoStack` test objects being created.  This PR adds module level fixtures to streamline the tests and reduce redundancy. These fixtures are added to all test files except `test_datasets.py` and `test_io.py`.  In `test_datasets.py`, fixtures are avoided because the unit tests are checking against the `datasets` module functionality.  In `test_io.py`, there are no redundancies to correct with fixtures.  Local testing has shown that the full test run is now approximately 30 % faster.

### Proposed Changes
- [x] Add fixtures to all test files except `test_datasets.py` and `test_io.py`

### Testing
- [x] **Linting:** Verified `ruff check` and `isort . --check` pass
- [x] **Unit Tests:** Ensured no failures when `in pytest`
- [x] **CI:** Ensured that all CI tests are passing