### PR TITLE
Removed scale deleteion from _fix_projection_axis in TomoStack

### DIFF
--- a/etspy/base.py
+++ b/etspy/base.py
@@ -683,7 +683,7 @@ class TomoStack(CommonStack):
             ax.name = "Projections"
         if ax.units == Undefined:
             ax.units = "degrees"
-            del ax.scale
+            ax.scale = 1.0
 
     def _fix_frames_axis(self, axis_number: int):
         ax = cast("Uda", self.axes_manager[axis_number])


### PR DESCRIPTION
Previously, the _fix_projection_axis method of TomoStack was deleting the projection axis scale which sets the scale to 0.0.

This causes a division by zero error when, for example, plotting sinograms extracted via TomoStack.extract_sinograms.  By removing the line that deleted the scale, the scale is set to 1.0 and plotting works correctly.

### MWE of Issue
```python
s = TomoStack(np.zeros([10,100,100]), tilts= np.linspace(0,180,10))
sino = s.extract_sinogram(0)
sino.plot()            # This line causes a division by zero error
```

### Description of the change
The TomoStack._fix_projection_axis method was altered so that the scale of the projection axis was not longer deleted.  When deleted, the scale would be set to 0.0.  Instead, it is now set to 1.0 with the current PR.

### Testing
- [X] **Linting:** Verified `ruff check` and `isort . --check` pass
- [X] **Unit Tests:** Ensured no failures when `in pytest`
- [ X ] **CI:** Ensured that all CI tests are passing