### PR TITLE
Fix get_radial_mask returning an empty mask for non-square shapes

### DIFF
--- a/etspy/tests/test_utils.py
+++ b/etspy/tests/test_utils.py
@@ -124,6 +124,16 @@ class TestHelperUtils:
         assert isinstance(mask, np.ndarray)
         assert mask.shape == (100, 100)
 
+    def test_radial_mask_non_square(self):
+        # A non-square shape with the default center should still produce a
+        # usable mask. Previously the default center placed rows//2 in the x
+        # slot, which drove the radius negative and returned an all-False mask.
+        mask = utils.get_radial_mask((100, 40))
+        assert mask.shape == (100, 40)
+        assert mask.any()
+        # The masked region should be centered on the array.
+        assert mask[50, 20]
+
 
 class TestWeightingFilter:
     """Test weighting filter."""

--- a/etspy/utils.py
+++ b/etspy/utils.py
@@ -378,7 +378,8 @@ def get_radial_mask(
     utilities
     """
     if center is None:
-        center = cast("tuple[int, int]", tuple(int(i / 2) for i in mask_shape))
+        # center is (x, y), so it maps to (cols, rows) of mask_shape (rows, cols).
+        center = (mask_shape[1] // 2, mask_shape[0] // 2)
     radius = min(
         center[0],
         center[1],


### PR DESCRIPTION
### Description of the change

I work on supply-chain and open-source security, and came across this while reading through the utilities.

`get_radial_mask` returns an all-False mask whenever the requested shape is not square. The default center is built as `(rows//2, cols//2)`, but the rest of the function treats `center` as `(x, y)` where `x` indexes columns and `y` indexes rows (matching the docstring). For a non-square shape those axes are swapped, so one of the `mask_shape[i] - center[j]` terms goes negative, the `radius` (a `min` over those terms) goes negative, and `dist < radius` is False everywhere.

Quick check on the current code:

- `(100, 40)` -> 0 True pixels
- `(40, 100)` -> 0 True pixels
- `(100, 100)` -> 7825 True pixels (works because it is square)

The fix computes the default center as `(cols//2, rows//2)` so it lands at the true array center for any shape. Square inputs are unaffected (the two orderings are identical there).

### Proposed Changes
- [x] Compute the default center in `(x, y)` order so non-square shapes get a correctly centered mask
- [x] Add a regression test for a non-square shape

### Testing
- [x] **Linting:** `ruff check` and `isort --check` pass on the changed files
- [x] **Unit Tests:** `TestHelperUtils` passes; the new `test_radial_mask_non_square` fails on the current code and passes with the fix