### PR TITLE
Fix non-uniform center-of-mass coordinate axis for even detector heights

### DIFF
--- a/etspy/align.py
+++ b/etspy/align.py
@@ -91,7 +91,7 @@ def get_coms(stack: "TomoStack", slices: np.ndarray) -> np.ndarray:
     """
     sinos = stack.data[:, :, slices]
     com_range = int(sinos.shape[1] / 2)
-    y_coordinates = np.linspace(-com_range, com_range, sinos.shape[1], dtype="int")
+    y_coordinates = np.linspace(-com_range, com_range, sinos.shape[1])
     total_mass = sinos.sum(1)
     coms = np.sum(np.transpose(sinos, [0, 2, 1]) * y_coordinates, 2) / total_mass
     return coms


### PR DESCRIPTION
### Description of the change

`get_coms` builds the detector y-axis it uses to weight the center-of-mass with `np.linspace(-com_range, com_range, ny, dtype="int")`. Casting to int truncates the coordinates, so when `ny` is even the axis is no longer evenly spaced (the step alternates between 1 and 2 pixels). A center of mass needs a uniform coordinate axis, so this puts a small systematic, row-dependent bias into every COM, which then feeds the tilt-axis alignment. Odd `ny` isn't affected because the values already land on integers.

Dropping `dtype="int"` restores the uniform spacing. `coms` is already a float result (it's divided by `total_mass`), so nothing downstream needs the integer axis.

### Proposed Changes

- [x] Use uniformly spaced float coordinates in `get_coms` instead of truncated integers.

### Testing

One thing to double check on your side: `test_tilt_align_com` and `test_tilt_align_com_no_locs` assert tilt-axis angles with an abs=0.5 tolerance. The corrected COM shifts even-height data by up to about a pixel, so please confirm those two still pass; if they drift, the expected angles may need a small nudge. I verified that the corrected axis is uniform and that odd `ny` is byte-identical before and after, but I couldn't run the full suite locally (astra-toolbox/hyperspy).